### PR TITLE
Fix/solver dll directories problems

### DIFF
--- a/.github/workflows/cmake_windows_manual.yml
+++ b/.github/workflows/cmake_windows_manual.yml
@@ -122,7 +122,6 @@ jobs:
         env:
           XPRESS: "${{ github.workspace }}/xpressmp813/bin/"
           SIRIUS_BIN_DIR: "${{ github.workspace }}/sirius-solver/SiriusInstall/bin"
-          XPRESS_BIN_DIR: "${{ github.workspace }}/xpressmp813/bin"
       - name: Run specific java tests
         working-directory: ./or-tools/build
         env:

--- a/.github/workflows/cmake_windows_manual.yml
+++ b/.github/workflows/cmake_windows_manual.yml
@@ -35,7 +35,7 @@ jobs:
           ref: antares_integration
       - name: Configure Sirius
         working-directory: ./sirius-solver
-        run: cmake -Ssrc -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=SiriusInstall -G "Visual Studio 16 2019"
+        run: cmake -Ssrc -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=SiriusInstall
       - name: Build & Install Sirius
         working-directory: ./sirius-solver
         run: cmake --build build/ --config Release --target INSTALL -- /maxcpucount
@@ -63,7 +63,7 @@ jobs:
           path: ./or-tools
       - name: Configure or-tools
         working-directory: ./or-tools
-        run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="build/install" -G "Visual Studio 16 2019" -DBUILD_DEPS=ON -DUSE_SIRIUS=ON -Dsirius_solver_DIR="${{ github.workspace }}/sirius-solver/SiriusInstall/cmake" -DUSE_XPRESS=ON -DXPRESS_ROOT="${{ github.workspace }}/xpressmp813" -DBUILD_PYTHON=ON -DBUILD_JAVA=ON -DBUILD_DOTNET=ON
+        run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="build/install" -DBUILD_DEPS=ON -DUSE_SIRIUS=ON -Dsirius_solver_DIR="${{ github.workspace }}/sirius-solver/SiriusInstall/cmake" -DUSE_XPRESS=ON -DXPRESS_ROOT="${{ github.workspace }}/xpressmp813" -DBUILD_PYTHON=OFF -DBUILD_JAVA=OFF -DBUILD_DOTNET=OFF
       - name: Build tests
         working-directory: ./or-tools
         run: cmake --build build --config Release --target ALL_BUILD INSTALL -v -- /maxcpucount

--- a/.github/workflows/cmake_windows_manual.yml
+++ b/.github/workflows/cmake_windows_manual.yml
@@ -121,7 +121,7 @@ jobs:
         run: ctest -V -C Release -R python_python_linear_programming
         env:
           XPRESS: "${{ github.workspace }}/xpressmp813/bin/"
-          SIRIUS_BIN_DIR: "${{ github.workspace }}/sirius-solver/SiriusInstall/bin"
+          SIRIUS: "${{ github.workspace }}/sirius-solver/SiriusInstall/bin"
       - name: Run specific java tests
         working-directory: ./or-tools/build
         env:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OR-Tools - Google Optimization Tools
+# fork by RTE of OR-Tools - Google Optimization Tools
 
 [![PyPI version](https://img.shields.io/pypi/v/ortools.svg)](https://pypi.org/project/ortools/)
 [![PyPI download](https://img.shields.io/pypi/dm/ortools.svg)](https://pypi.org/project/ortools/#files)
@@ -12,6 +12,21 @@
 [![Discord](https://img.shields.io/discord/693088862481678374?color=7289DA&logo=discord&style=plastic)](https://discord.gg/ENkQrdf)
 
 Google's software suite for combinatorial optimization.
+
+This fork add an improved support for Xpress solver and
+add the interface to the open source [Sirius](https://github.com/rte-france/sirius-solver) solver
+developed by [RTE](https://www.rte-france.com/).
+
+## Specificities of this ortools version
+### Using Xpress
+In order to use a version of ortools with the support of Xpress, a valid Xpress installation is required.
+Ortools looks for the environment variable `XPRESS` that contains the path of the dynamic libraries of the solver.
+
+### Using Sirius
+In order to use a version of ortools with the support of Sirius,
+the dynamic library of Sirius must be present on the machine.
+The environment must contain the variable `SIRIUS` set to the path where the `sirius_solver.so` or `sirius_solver.dll`
+can be found.
 
 ## Table of Contents
 

--- a/ortools/linear_solver/python/linear_solver.i
+++ b/ortools/linear_solver/python/linear_solver.i
@@ -32,7 +32,7 @@
 import os as _os
 if hasattr(_os, 'add_dll_directory'):
 try:
-    _os.add_dll_directory(_os.getenv('SIRIUS_BIN_DIR'))
+    _os.add_dll_directory(_os.getenv('SIRIUS'))
 catch AttributeError:
     pass
 try:

--- a/ortools/linear_solver/python/linear_solver.i
+++ b/ortools/linear_solver/python/linear_solver.i
@@ -31,8 +31,14 @@
 %pythonbegin %{
 import os as _os
 if hasattr(_os, 'add_dll_directory'):
-    _os.add_dll_directory(_os.getenv('SIRIUS_BIN_DIR', ''))
-    _os.add_dll_directory(_os.getenv('XPRESS_BIN_DIR', ''))
+try:
+    _os.add_dll_directory(_os.getenv('SIRIUS_BIN_DIR'))
+catch AttributeError:
+    pass
+try:
+    _os.add_dll_directory(_os.getenv('XPRESS'))
+catch AttributeError:
+    pass
 %}
 
 %include "ortools/base/base.i"


### PR DESCRIPTION
The Windows version of the pyhton package needs to know where to look for the `.dll` of Sirius and Xpress.

### There are two problems:

#### problem 1
The build phase add to the python package a research for 2 environment variables (`SIRIUS_BIN_DIR` and `XPRESS_BIN_DIR`) that should indicate where the `dll` are found.
This research is kept even if no support for Xpress or Sirius is active.

```python
 _os.add_dll_directory(_os.getenv('SIRIUS_BIN_DIR', ''))
    _os.add_dll_directory(_os.getenv('XPRESS_BIN_DIR', ''))
```
If one variable is not found, `_os.add_dll_directory()` raises an exception since an empty string is not a valid input parameter.

#### problem 2
The name of these variable are very arbitrary and only used by the python package. The standard variable for the XPRESS is simply `XPRESS` as hard-coded in the `C++` code. Should we keep the value hardcoded?
The name of the Sirius dll_dir is not specified anywhere but on this file `ortools/linear_solver/python/linear_solver.i` and is not uniform with the naming of the Xpress variables used in the `C++` code.

## I propose two modifications:
- catch the exception in order to avoid a crash if an environment variable is not found (the behaviour will be similar to having the variable set to a path without the dll).
- change the name of the variables to `XPRESS` and `SIRIUS`

## todo

- [x] add information regarding the environment variables needed by ortools somewhere in the doc or Readme