### PR TITLE
Reflecting MPSolver::Write in csharp/java/python APIs

### DIFF
--- a/examples/dotnet/cslinearprogramming.cs
+++ b/examples/dotnet/cslinearprogramming.cs
@@ -121,6 +121,9 @@ public class CsLinearProgramming
             string model = solver.ExportModelAsLpFormat(false);
             Console.WriteLine(model);
         }
+        string modelExportPath = "model_" + solverType + ".mps";
+        Console.WriteLine("Writing problem to " + modelExportPath);
+        solver.Write(modelExportPath);
 
         Solver.ResultStatus resultStatus = solver.Solve();
 

--- a/examples/java/LinearProgramming.java
+++ b/examples/java/LinearProgramming.java
@@ -66,6 +66,9 @@ public class LinearProgramming {
       String model = solver.exportModelAsLpFormat();
       System.out.println(model);
     }
+    String modelExportPath = "model_" + solverType + ".mps";
+    System.out.println("Writing problem to " + modelExportPath);
+    solver.write(modelExportPath);
 
     final MPSolver.ResultStatus resultStatus = solver.solve();
 

--- a/examples/python/linear_programming.py
+++ b/examples/python/linear_programming.py
@@ -41,6 +41,10 @@ def RunLinearExampleNaturalLanguageAPI(optimization_problem_type):
     sum_of_vars = sum([x1, x2, x3])
     c2 = solver.Add(sum_of_vars <= 100.0, 'OtherConstraintName')
 
+    model_export_path = "model_" + optimization_problem_type + ".mps"
+    print("Writing problem to " + model_export_path)
+    solver.Write(model_export_path)
+
     SolveAndPrint(solver, [x1, x2, x3], [c0, c1, c2])
     # Print a linear expression's solution value.
     print('Sum of vars: %s = %s' % (sum_of_vars, sum_of_vars.solution_value()))

--- a/ortools/linear_solver/csharp/linear_solver.i
+++ b/ortools/linear_solver/csharp/linear_solver.i
@@ -166,6 +166,7 @@ CONVERT_VECTOR(operations_research::MPVariable, MPVariable)
 // Extend code.
 %unignore operations_research::MPSolver::ExportModelAsLpFormat(bool);
 %unignore operations_research::MPSolver::ExportModelAsMpsFormat(bool, bool);
+%unignore operations_research::MPSolver::Write;
 %unignore operations_research::MPSolver::SetHint(
     const std::vector<operations_research::MPVariable*>&,
     const std::vector<double>&);

--- a/ortools/linear_solver/java/linear_solver.i
+++ b/ortools/linear_solver/java/linear_solver.i
@@ -376,6 +376,7 @@ PROTO2_RETURN(
 %rename (suppressOutput) operations_research::MPSolver::SuppressOutput;  // no test
 %rename (lookupConstraintOrNull) operations_research::MPSolver::LookupConstraintOrNull;  // no test
 %rename (lookupVariableOrNull) operations_research::MPSolver::LookupVariableOrNull;  // no test
+%rename (write) operations_research::MPSolver::Write;
 
 // Expose very advanced parts of the MPSolver API. For expert users only.
 %rename (computeConstraintActivities) operations_research::MPSolver::ComputeConstraintActivities;

--- a/ortools/linear_solver/python/linear_solver.i
+++ b/ortools/linear_solver/python/linear_solver.i
@@ -347,6 +347,7 @@ PY_CONVERT(MPVariable);
 %unignore operations_research::MPSolver::NextSolution;
 // ExportModelAsLpFormat() is also visible: it's overridden by an %extend, above.
 // ExportModelAsMpsFormat() is also visible: it's overridden by an %extend, above.
+%unignore operations_research::MPSolver::Write;
 
 // Expose very advanced parts of the MPSolver API. For expert users only.
 %unignore operations_research::MPSolver::ComputeConstraintActivities;


### PR DESCRIPTION
Reflecting the native solver export method in csharp/java/python APIs. Fix #34 