### PR TITLE
Bump sirius tags, fix unit tests

### DIFF
--- a/.github/workflows/ubuntu-windows.yml
+++ b/.github/workflows/ubuntu-windows.yml
@@ -34,7 +34,7 @@ jobs:
         sirius: [ON, OFF]
         shared: [ON, OFF]
         extras: [ON, OFF]
-        sirius-release-tag: [antares-integration-v1.1]
+        sirius-release-tag: [antares-integration-v1.2]
         build-examples: [OFF]
         # the matrix is a bit complicated because
         # we need static C++-libraries for both Windows and linux
@@ -92,7 +92,7 @@ jobs:
             dotnet: OFF
             xprs: OFF
             sirius: ON
-            sirius-release-tag: antares-integration-v1.1
+            sirius-release-tag: antares-integration-v1.2
             shared: OFF
             extras: OFF
             publish-or: ON
@@ -103,7 +103,7 @@ jobs:
             dotnet: OFF
             xprs: OFF
             sirius: ON
-            sirius-release-tag: antares-integration-v1.1
+            sirius-release-tag: antares-integration-v1.2
             shared: OFF
             extras: OFF
             publish-or: ON
@@ -116,7 +116,7 @@ jobs:
             dotnet: OFF
             java: OFF
             sirius: ON
-            sirius-release-tag: metrix-integration-v0.1
+            sirius-release-tag: metrix-integration-v0.2
             xprs: OFF
             build-examples: ON
           - os: ubuntu-20.04
@@ -128,7 +128,7 @@ jobs:
             dotnet: OFF
             java: OFF
             sirius: ON
-            sirius-release-tag: metrix-integration-v0.1
+            sirius-release-tag: metrix-integration-v0.2
             xprs: ON
             build-examples: ON
 
@@ -142,7 +142,7 @@ jobs:
           XPRS=${{ matrix.xprs }}
           [ $XPRS == "ON" ] && WITH_XPRS="_xprs" || WITH_XPRS=""
           SIRIUS_TAG=${{ matrix.sirius-release-tag }}
-          [ $SIRIUS_TAG == "metrix-integration-v0.1" ] && SIRIUS_BRANCH="-metrix" || SIRIUS_BRANCH=""
+          [ $SIRIUS_TAG == "metrix-integration-v0.2" ] && SIRIUS_BRANCH="-metrix" || SIRIUS_BRANCH=""
           SIRIUS=${{ matrix.sirius }}
           [ $SIRIUS == "ON" ] && WITH_SIRIUS="_sirius$SIRIUS_BRANCH" || WITH_SIRIUS=""
           OS="_${{ matrix.os }}"

--- a/ortools/linear_solver/unittests/sirius_interface.cc
+++ b/ortools/linear_solver/unittests/sirius_interface.cc
@@ -536,7 +536,7 @@ namespace operations_research {
     EXPECT_GE(solver.SolverVersion().size(), 36);
   }
 
-  TEST(SiriusInterface, DISABLED_Write) {
+  TEST(SiriusInterface, Write) {
     // SRSwritempsprob not fully implemented in sirius-solver
     UNITTEST_INIT_MIP();
     MPVariable* x1 = solver.MakeIntVar(-1.2, 9.3, "x1");
@@ -583,24 +583,6 @@ BOUNDS
  UP BNDVALUE  C0000001  5.000000000
 ENDATA
 )");
-  }
-
-  TEST(SiriusInterface, Write) {
-    UNITTEST_INIT_MIP();
-    MPVariable* x1 = solver.MakeIntVar(-1.2, 9.3, "x1");
-    MPVariable* x2 = solver.MakeNumVar(-1, 5, "x2");
-    MPConstraint* c1 = solver.MakeRowConstraint(-solver.infinity(), 1);
-    c1->SetCoefficient(x1, 3);
-    c1->SetCoefficient(x2, 1.5);
-    MPConstraint* c2 = solver.MakeRowConstraint(3, solver.infinity());
-    c2->SetCoefficient(x2, -1.1);
-    MPObjective* obj = solver.MutableObjective();
-    obj->SetMaximization();
-    obj->SetCoefficient(x1, 1);
-    obj->SetCoefficient(x2, 2);
-
-    std::string tmpName = std::string(std::tmpnam(nullptr)) + ".mps";
-    EXPECT_THROW(solver.Write(tmpName), std::logic_error);
   }
 
   TEST(SiriusInterface, DISABLED_SetPrimalTolerance) {


### PR DESCRIPTION
### MPS files are slightly different on sirius-metrix and sirius-antares
```diff
@@ -1,4 +1,4 @@
-* Nombre de variables:   2
-* Nombre de contraintes: 2
+* Number of variables:   2
+* Number of constraints: 2
 NAME          Pb Solve
 ROWS
@@ -16,5 +16,6 @@
     RHSVAL    R0000001  3.000000000
 BOUNDS
- BV BNDVALUE  C0000000
+ LI BNDVALUE  C0000000  -1
+ UI BNDVALUE  C0000000  9
  LO BNDVALUE  C0000001  -1.000000000
  UP BNDVALUE  C0000001  5.000000000
```