### PR TITLE
Graceful warning if some XPRESS functions are not found

### DIFF
--- a/ortools/base/dynamic_library.h
+++ b/ortools/base/dynamic_library.h
@@ -28,9 +28,8 @@
 #include <dlfcn.h>
 #endif
 
-#define MAX_FUNCTIONS_NOT_FOUND 10
-
 class DynamicLibrary {
+static constexpr size_t kMaxFunctionsNotFound = 10;
  public:
   DynamicLibrary() : library_handle_(nullptr) {}
 
@@ -73,7 +72,7 @@ class DynamicLibrary {
 #endif
     // We don't really need the full list of missing functions,
     // just a few are enough.
-    if (!function_address && functions_not_found_.size() < MAX_FUNCTIONS_NOT_FOUND)
+    if (!function_address && functions_not_found_.size() < kMaxFunctionsNotFound)
         functions_not_found_.push_back(function_name);
 
     return TypeParser<T>::CreateFunction(function_address);

--- a/ortools/base/dynamic_library.h
+++ b/ortools/base/dynamic_library.h
@@ -57,6 +57,7 @@ class DynamicLibrary {
   }
 
   bool LibraryIsLoaded() const { return library_handle_ != nullptr; }
+
   const std::vector<std::string>& FunctionsNotFound() const {
       return functions_not_found_;
   }

--- a/ortools/base/dynamic_library.h
+++ b/ortools/base/dynamic_library.h
@@ -28,6 +28,8 @@
 #include <dlfcn.h>
 #endif
 
+#define MAX_FUNCTIONS_NOT_FOUND 10
+
 class DynamicLibrary {
  public:
   DynamicLibrary() : library_handle_(nullptr) {}
@@ -68,7 +70,9 @@ class DynamicLibrary {
 #else
         dlsym(library_handle_, function_name);
 #endif
-    if (!function_address)
+    // We don't really need the full list of missing functions,
+    // just a few are enough.
+    if (!function_address && functions_not_found_.size() < MAX_FUNCTIONS_NOT_FOUND)
         functions_not_found_.push_back(function_name);
 
     return TypeParser<T>::CreateFunction(function_address);

--- a/ortools/base/dynamic_library.h
+++ b/ortools/base/dynamic_library.h
@@ -14,10 +14,10 @@
 #ifndef OR_TOOLS_BASE_DYNAMIC_LIBRARY_H_
 #define OR_TOOLS_BASE_DYNAMIC_LIBRARY_H_
 
-#include <vector>
 #include <functional>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "ortools/base/logging.h"
 
@@ -56,7 +56,7 @@ class DynamicLibrary {
 
   bool LibraryIsLoaded() const { return library_handle_ != nullptr; }
   const std::vector<std::string>& FunctionsNotFound() const {
-      return functions_not_found;
+      return functions_not_found_;
   }
 
   template <typename T>
@@ -69,7 +69,7 @@ class DynamicLibrary {
         dlsym(library_handle_, function_name);
 #endif
     if (!function_address)
-        functions_not_found.push_back(function_name);
+        functions_not_found_.push_back(function_name);
 
     return TypeParser<T>::CreateFunction(function_address);
   }
@@ -93,7 +93,7 @@ class DynamicLibrary {
  private:
   void* library_handle_ = nullptr;
   std::string library_name_;
-  std::vector<std::string> functions_not_found;
+  std::vector<std::string> functions_not_found_;
 
   template <typename T>
   struct TypeParser {};

--- a/ortools/xpress/environment.cc
+++ b/ortools/xpress/environment.cc
@@ -2206,7 +2206,7 @@ absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
 
   auto notFound = xpress_dynamic_library->FunctionsNotFound();
   if (!notFound.empty()) {
-    return absl::NotFoundError(absl::StrCat("Could not find the following functions. [",
+    return absl::NotFoundError(absl::StrCat("Could not find the following functions (list may not be exhaustive). [",
                                             absl::StrJoin(notFound, "', '"),
                                             "]. Please make sure that your XPRESS install is up-to-date (>= 8.13.0)."));
   }

--- a/ortools/xpress/environment.cc
+++ b/ortools/xpress/environment.cc
@@ -1578,7 +1578,7 @@ std::function<int(XPRSprob prob, int options, const char* flags,
                   const double solution[], double refined[], int* p_status)>
     XPRSrefinemipsol = nullptr;
 
-void LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
+absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
   // This was generated with the parse_header_xpress.py script.
   // See the comment at the top of the script.
 
@@ -2203,6 +2203,16 @@ void LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
   xpress_dynamic_library->GetFunction(&XPRSbasiscondition,
                                       "XPRSbasiscondition");
   xpress_dynamic_library->GetFunction(&XPRSrefinemipsol, "XPRSrefinemipsol");
+
+  auto notFound = xpress_dynamic_library->FunctionsNotFound();
+  if (notFound.empty())
+      return absl::OkStatus();
+  else {
+      absl::NotFoundError(absl::StrCat(
+          "Could not find the following functions. [",
+          absl::StrJoin(notFound, "', '"),
+          "]. Please make sure that your XPRESS install is up-to-date"));
+  }
 }
 
 void printXpressBanner(bool error) {
@@ -2280,8 +2290,7 @@ absl::Status LoadXpressDynamicLibrary(std::string& xpresspath) {
     }
 
     if (xpress_library.LibraryIsLoaded()) {
-      LoadXpressFunctions(&xpress_library);
-      xpress_load_status = absl::OkStatus();
+      xpress_load_status =  LoadXpressFunctions(&xpress_library);
     } else {
       xpress_load_status = absl::NotFoundError(absl::StrCat(
           "Could not find the Xpress shared library. Looked in: [",
@@ -2299,7 +2308,7 @@ bool initXpressEnv(bool verbose, int xpress_oem_license_key) {
   std::string xpresspath;
   absl::Status status = LoadXpressDynamicLibrary(xpresspath);
   if (!status.ok()) {
-    LOG(ERROR) << status << "\n";
+    LOG(WARNING) << status << "\n";
     return false;
   }
 

--- a/ortools/xpress/environment.cc
+++ b/ortools/xpress/environment.cc
@@ -2208,7 +2208,7 @@ absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
   if (!notFound.empty()) {
     return absl::NotFoundError(absl::StrCat("Could not find the following functions. [",
                                             absl::StrJoin(notFound, "', '"),
-                                            "]. Please make sure that your XPRESS install is up-to-date"));
+                                            "]. Please make sure that your XPRESS install is up-to-date (>= 8.13.0)."));
   }
   return absl::OkStatus();
 }

--- a/ortools/xpress/environment.cc
+++ b/ortools/xpress/environment.cc
@@ -2205,14 +2205,12 @@ absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
   xpress_dynamic_library->GetFunction(&XPRSrefinemipsol, "XPRSrefinemipsol");
 
   auto notFound = xpress_dynamic_library->FunctionsNotFound();
-  if (notFound.empty())
-      return absl::OkStatus();
-  else {
-      absl::NotFoundError(absl::StrCat(
-          "Could not find the following functions. [",
-          absl::StrJoin(notFound, "', '"),
-          "]. Please make sure that your XPRESS install is up-to-date"));
+  if (!notFound.empty()) {
+    return absl::NotFoundError(absl::StrCat("Could not find the following functions. [",
+                                            absl::StrJoin(notFound, "', '"),
+                                            "]. Please make sure that your XPRESS install is up-to-date"));
   }
+  return absl::OkStatus();
 }
 
 void printXpressBanner(bool error) {


### PR DESCRIPTION
### Current behavior if at least one XPRESS function isn't found
The application crashes because `LOG(FATAL)` is called

```
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0120 10:07:31.982523 12256 environment.cc:2273] Found the Xpress library in C:\xpressmp\bin\xprs.dll.
F0120 10:07:31.983064 12256 dynamic_library.h:68] Check failed: function_address != nullptr Error: could not find function XPRSaddpwlcons in C:\xpressmp\bin\xprs.dll
*** Check failure stack trace: ***
```

### New behavior
A warning is emitted with the missing function names and the following message

```
W0120 13:48:44.598562 198294 environment.cc:2309] NOT_FOUND: Could not find the following functions. [XPRSaddpwlcons', 'XPRSaddpwlcons64', 'XPRSgetpwlcons', 'XPRSgetpwlcons64', 'XPRSaddgencons', 'XPRSaddgencons64', 'XPRSgetgencons', 'XPRSgetgencons64', 'XPRSdelpwlcons', 'XPRSdelgencons', 'XPRSgetrowflags', 'XPRSclearrowflags', 'XPRSsetcbcomputerestart', 'XPRSgetcbcomputerestart', 'XPRSaddcbcomputerestart', 'XPRSremovecbcomputerestart', 'XPRSbndsa', 'XPRS_ge_setcomputeallowed', 'XPRS_ge_getcomputeallowed]. Please make sure that your XPRESS install is up-to-date (>= 8.13.0).
```

XPRESS is marked as unavailable through e.g `MPSolver::SupportsProblemType` or `MPSolver::CreateSolver`.