### PR TITLE
[Draft] Rename JNI module "main"

### DIFF
--- a/ortools/linear_solver/java/CMakeLists.txt
+++ b/ortools/linear_solver/java/CMakeLists.txt
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 set_property(SOURCE linear_solver.i PROPERTY CPLUSPLUS ON)
-set_property(SOURCE linear_solver.i PROPERTY SWIG_MODULE_NAME main_research_linear_solver)
+set_property(SOURCE linear_solver.i PROPERTY SWIG_MODULE_NAME main)
 set_property(SOURCE linear_solver.i PROPERTY COMPILE_DEFINITIONS
   ${OR_TOOLS_COMPILE_DEFINITIONS} ABSL_MUST_USE_RESULT=)
 set_property(SOURCE linear_solver.i PROPERTY COMPILE_OPTIONS


### PR DESCRIPTION
As the official OR-Tools repository before v9.2 used the Make build system, the generated JNI was named "main_research_linear_solver".
Since we use CMake instead, in order to be compatible with their jars published on maven central, we had to rename the JNI generated by CMake "main_research_linear_solver" as well.

However, since [v9.3](https://github.com/google/or-tools/releases/tag/v9.3), Google also use the CMake build system. So now their JNI is called "main" (see [original file](https://github.com/google/or-tools/blob/stable/ortools/linear_solver/java/CMakeLists.txt)).
So now we can go back to naming it "main" like Google, to be compatible with their jars.

This change reverts [this commit](https://github.com/rte-france/or-tools/commit/56000cc36b830e7155a7ff6dee7fad15946e27a9).