### PR TITLE
Update all objective coefficients in one time

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -642,8 +642,7 @@ XpressInterface::XpressInterface(MPSolver* const solver, bool mip)
       mLp(0),
       mMip(mip),
       supportIncrementalExtraction(false),
-      slowUpdates(static_cast<SlowUpdates>(SlowSetObjectiveCoefficient |
-                                           SlowClearObjective)),
+      slowUpdates(SlowClearObjective),
       mapStringControls_(getMapStringControls()),
       mapDoubleControls_(getMapDoubleControls()),
       mapIntegerControls_(getMapIntControls()),


### PR DESCRIPTION
## Short description
This PR is about changing the behavior of `XpressInterface::SetObjectiveCoefficient`, the function which is used to set the objective coefficient for a single variable. This approach proves to be much faster than individual updates.

## Before
`XpressInterface::SetObjectiveCoefficient` immediately changes the coefficients by calling
```c
int const col = variable->index();
CHECK_STATUS(XPRSchgobj(mLp, 1, &col, &coefficient));
```

## After
The model is invalidated by calling `InvalidateModelSynchronization`. When calling `MPSolver::Solve`, all coefficients are extracted in one time
```cpp
void XpressInterface::ExtractObjective() {
  // NOTE: The code assumes that the objective expression does not contain
  //       any non-zero duplicates.

  int const cols = XPRSgetnumcols(mLp);
  // DCHECK_EQ(last_variable_index_, cols);

  unique_ptr<int[]> ind(new int[cols]);
  unique_ptr<double[]> val(new double[cols]);
  for (int j = 0; j < cols; ++j) {
    ind[j] = j;
    val[j] = 0.0;
  }

  const auto& coeffs = solver_->objective_->coefficients_;
  for (auto it = coeffs.begin(); it != coeffs.end(); ++it) {
    int const idx = it->first->index();
    if (variable_is_extracted(idx)) {
      DCHECK_LT(idx, cols);
      val[idx] = it->second;
    }
  }

  CHECK_STATUS(XPRSchgobj(mLp, cols, ind.get(), val.get()));
  CHECK_STATUS(XPRSsetobjoffset(mLp, solver_->Objective().offset()));
}
```