### PR TITLE
Feature/improve xpress env variables

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -85,8 +85,7 @@ jobs:
         run: |
           cd ${{ env.XPRESS_INSTALL_DIR }}
           echo "XPRESSDIR=$PWD" >> $GITHUB_ENV
-          echo "XPRESS=$PWD/bin" >> $GITHUB_ENV
-          echo "XPRESS_LIB=$PWD/lib" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=$PWD/bin/xpauth.xpr" >> $GITHUB_ENV
 
       - name: Download Sirius
         if : ${{ matrix.sirius == 'ON' }}

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -123,8 +123,7 @@ jobs:
         run: |
           cd ${{ env.XPRESS_INSTALL_DIR }}
           echo "XPRESSDIR=$PWD" >> $GITHUB_ENV
-          echo "XPRESS=$PWD/bin" >> $GITHUB_ENV
-          echo "XPRESS_LIB=$PWD/lib" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=$PWD/bin/xpauth.xpr" >> $GITHUB_ENV
 
       - name: Configure OR-Tools
         run: |

--- a/.github/workflows/ubuntu-windows.yml
+++ b/.github/workflows/ubuntu-windows.yml
@@ -20,8 +20,7 @@ jobs:
     env:
       SIRIUS_RELEASE_TAG: ${{ matrix.sirius-release-tag }}
       XPRESSDIR: ${{ github.workspace }}/xpressmp
-      XPRESS: ${{ github.workspace }}/xpressmp/bin
-      XPRS_LIB_PATH: ${{ github.workspace }}/xpressmp/lib
+      XPAUTH_PATH: ${{ github.workspace }}/xpressmp/bin/xpauth.xpr
       SIRIUS_INSTALL_PATH : ${{ github.workspace }}/sirius_install
       SIRIUS: ${{ github.workspace }}/sirius_install/bin
     strategy:
@@ -201,7 +200,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'windows') }}
         shell: bash
         run: |
-          echo "${{ env.XPRESS }}" >> $GITHUB_PATH
+          echo "${{ env.XPAUTH_PATH }}" >> $GITHUB_PATH
           echo "${{ env.SIRIUS }}" >> $GITHUB_PATH
 
       - name: Configure OR-Tools
@@ -223,7 +222,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') }}
         shell: bash
         run: |
-          LD_PATH="${{ env.SIRIUS_INSTALL_PATH }}/lib/:${{ env.XPRS_LIB_PATH }}/"
+          LD_PATH="${{ env.SIRIUS_INSTALL_PATH }}/lib/"
           echo "LD_LIBRARY_PATH=$LD_PATH" >> $GITHUB_ENV
 
       - name: Build & run CMake example project linux

--- a/ortools/xpress/environment.cc
+++ b/ortools/xpress/environment.cc
@@ -42,50 +42,118 @@ std::function<int(int* p_i, char* p_c)> XPRSlicense = nullptr;
 std::function<int(char* banner)> XPRSgetbanner = nullptr;
 std::function<int(char* version)> XPRSgetversion = nullptr;
 std::function<int(XPRSprob prob, int control)> XPRSsetdefaultcontrol = nullptr;
-std::function<int(XPRSprob prob, int control, int value)> XPRSsetintcontrol = nullptr;
-std::function<int(XPRSprob prob, int control, XPRSint64 value)> XPRSsetintcontrol64 = nullptr;
-std::function<int(XPRSprob prob, int control, double value)> XPRSsetdblcontrol = nullptr;
-std::function<int(XPRSprob prob, int control, const char* value)> XPRSsetstrcontrol = nullptr;
-std::function<int(XPRSprob prob, int control, int* p_value)> XPRSgetintcontrol = nullptr;
-std::function<int(XPRSprob prob, int control, XPRSint64* p_value)> XPRSgetintcontrol64 = nullptr;
-std::function<int(XPRSprob prob, int control, double* p_value)> XPRSgetdblcontrol = nullptr;
-std::function<int(XPRSprob prob, int control, char* value, int maxbytes, int* p_nbytes)> XPRSgetstringcontrol = nullptr;
-std::function<int(XPRSprob prob, int attrib, int* p_value)> XPRSgetintattrib = nullptr;
-std::function<int(XPRSprob prob, int attrib, double* p_value)> XPRSgetdblattrib = nullptr;
-std::function<int(XPRSprob prob, const char* probname, int ncols, int nrows, const char rowtype[], const double rhs[], const double rng[], const double objcoef[], const int start[], const int collen[], const int rowind[], const double rowcoef[], const double lb[], const double ub[])> XPRSloadlp = nullptr;
-std::function<int(XPRSprob prob, const char* probname, int ncols, int nrows, const char rowtype[], const double rhs[], const double rng[], const double objcoef[], const XPRSint64 start[], const int collen[], const int rowind[], const double rowcoef[], const double lb[], const double ub[])> XPRSloadlp64 = nullptr;
-std::function<int(XPRSprob prob, double objcoef[], int first, int last)> XPRSgetobj = nullptr;
-std::function<int(XPRSprob prob, double rhs[], int first, int last)> XPRSgetrhs = nullptr;
-std::function<int(XPRSprob prob, double rng[], int first, int last)> XPRSgetrhsrange = nullptr;
-std::function<int(XPRSprob prob, double lb[], int first, int last)> XPRSgetlb = nullptr;
-std::function<int(XPRSprob prob, double ub[], int first, int last)> XPRSgetub = nullptr;
-std::function<int(XPRSprob prob, int row, int col, double* p_coef)> XPRSgetcoef = nullptr;
-std::function<int(XPRSprob prob, int nrows, int ncoefs, const char rowtype[], const double rhs[], const double rng[], const int start[], const int colind[], const double rowcoef[])> XPRSaddrows = nullptr;
-std::function<int(XPRSprob prob, int nrows, const int rowind[])> XPRSdelrows = nullptr;
-std::function<int(XPRSprob prob, int ncols, int ncoefs, const double objcoef[], const int start[], const int rowind[], const double rowcoef[], const double lb[], const double ub[])> XPRSaddcols = nullptr;
-std::function<int(XPRSprob prob, int type, const char names[], int first, int last)> XPRSaddnames = nullptr;
-std::function<int(XPRSprob prob, int type, char names[], int first, int last)> XPRSgetnames = nullptr;
-std::function<int(XPRSprob prob, int ncols, const int colind[])> XPRSdelcols = nullptr;
-std::function<int(XPRSprob prob, int ncols, const int colind[], const char coltype[])> XPRSchgcoltype = nullptr;
-std::function<int(XPRSprob prob, const int rowstat[], const int colstat[])> XPRSloadbasis = nullptr;
+std::function<int(XPRSprob prob, int control, int value)> XPRSsetintcontrol =
+    nullptr;
+std::function<int(XPRSprob prob, int control, XPRSint64 value)>
+    XPRSsetintcontrol64 = nullptr;
+std::function<int(XPRSprob prob, int control, double value)> XPRSsetdblcontrol =
+    nullptr;
+std::function<int(XPRSprob prob, int control, const char* value)>
+    XPRSsetstrcontrol = nullptr;
+std::function<int(XPRSprob prob, int control, int* p_value)> XPRSgetintcontrol =
+    nullptr;
+std::function<int(XPRSprob prob, int control, XPRSint64* p_value)>
+    XPRSgetintcontrol64 = nullptr;
+std::function<int(XPRSprob prob, int control, double* p_value)>
+    XPRSgetdblcontrol = nullptr;
+std::function<int(XPRSprob prob, int control, char* value, int maxbytes,
+                  int* p_nbytes)>
+    XPRSgetstringcontrol = nullptr;
+std::function<int(XPRSprob prob, int attrib, int* p_value)> XPRSgetintattrib =
+    nullptr;
+std::function<int(XPRSprob prob, int attrib, double* p_value)>
+    XPRSgetdblattrib = nullptr;
+std::function<int(XPRSprob prob, const char* probname, int ncols, int nrows,
+                  const char rowtype[], const double rhs[], const double rng[],
+                  const double objcoef[], const int start[], const int collen[],
+                  const int rowind[], const double rowcoef[], const double lb[],
+                  const double ub[])>
+    XPRSloadlp = nullptr;
+std::function<int(XPRSprob prob, const char* probname, int ncols, int nrows,
+                  const char rowtype[], const double rhs[], const double rng[],
+                  const double objcoef[], const XPRSint64 start[],
+                  const int collen[], const int rowind[],
+                  const double rowcoef[], const double lb[], const double ub[])>
+    XPRSloadlp64 = nullptr;
+std::function<int(XPRSprob prob, double objcoef[], int first, int last)>
+    XPRSgetobj = nullptr;
+std::function<int(XPRSprob prob, double rhs[], int first, int last)>
+    XPRSgetrhs = nullptr;
+std::function<int(XPRSprob prob, double rng[], int first, int last)>
+    XPRSgetrhsrange = nullptr;
+std::function<int(XPRSprob prob, double lb[], int first, int last)> XPRSgetlb =
+    nullptr;
+std::function<int(XPRSprob prob, double ub[], int first, int last)> XPRSgetub =
+    nullptr;
+std::function<int(XPRSprob prob, int row, int col, double* p_coef)>
+    XPRSgetcoef = nullptr;
+std::function<int(XPRSprob prob, int nrows, int ncoefs, const char rowtype[],
+                  const double rhs[], const double rng[], const int start[],
+                  const int colind[], const double rowcoef[])>
+    XPRSaddrows = nullptr;
+std::function<int(XPRSprob prob, int nrows, const int rowind[])> XPRSdelrows =
+    nullptr;
+std::function<int(XPRSprob prob, int ncols, int ncoefs, const double objcoef[],
+                  const int start[], const int rowind[], const double rowcoef[],
+                  const double lb[], const double ub[])>
+    XPRSaddcols = nullptr;
+std::function<int(XPRSprob prob, int type, const char names[], int first,
+                  int last)>
+    XPRSaddnames = nullptr;
+std::function<int(XPRSprob prob, int type, char names[], int first, int last)>
+    XPRSgetnames = nullptr;
+std::function<int(XPRSprob prob, int ncols, const int colind[])> XPRSdelcols =
+    nullptr;
+std::function<int(XPRSprob prob, int ncols, const int colind[],
+                  const char coltype[])>
+    XPRSchgcoltype = nullptr;
+std::function<int(XPRSprob prob, const int rowstat[], const int colstat[])>
+    XPRSloadbasis = nullptr;
 std::function<int(XPRSprob prob)> XPRSpostsolve = nullptr;
 std::function<int(XPRSprob prob, int objsense)> XPRSchgobjsense = nullptr;
 std::function<int(XPRSprob prob, char* errmsg)> XPRSgetlasterror = nullptr;
-std::function<int(XPRSprob prob, int rowstat[], int colstat[])> XPRSgetbasis = nullptr;
-std::function<int(XPRSprob prob, const char* filename, const char* flags)> XPRSwriteprob = nullptr;
-std::function<int(XPRSprob prob, char rowtype[], int first, int last)> XPRSgetrowtype = nullptr;
-std::function<int(XPRSprob prob, char coltype[], int first, int last)> XPRSgetcoltype = nullptr;
-std::function<int(XPRSprob prob, int nbounds, const int colind[], const char bndtype[], const double bndval[])> XPRSchgbounds = nullptr;
-std::function<int(XPRSprob prob, int length, const double solval[], const int colind[], const char* name)> XPRSaddmipsol = nullptr;
-std::function<int(XPRSprob prob, double x[], double slack[], double duals[], double djs[])> XPRSgetlpsol = nullptr;
-std::function<int(XPRSprob prob, double x[], double slack[])> XPRSgetmipsol = nullptr;
-std::function<int(XPRSprob prob, int ncols, const int colind[], const double objcoef[])> XPRSchgobj = nullptr;
-std::function<int(XPRSprob prob, int row, int col, double coef)> XPRSchgcoef = nullptr;
-std::function<int(XPRSprob prob, int ncoefs, const int rowind[], const int colind[], const double rowcoef[])> XPRSchgmcoef = nullptr;
-std::function<int(XPRSprob prob, int nrows, const int rowind[], const double rhs[])> XPRSchgrhs = nullptr;
-std::function<int(XPRSprob prob, int nrows, const int rowind[], const double rng[])> XPRSchgrhsrange = nullptr;
-std::function<int(XPRSprob prob, int nrows, const int rowind[], const char rowtype[])> XPRSchgrowtype = nullptr;
-std::function<int(XPRSprob prob, void (XPRS_CC *f_message)(XPRSprob cbprob, void* cbdata, const char* msg, int msglen, int msgtype), void* p)> XPRSsetcbmessage = nullptr;
+std::function<int(XPRSprob prob, int rowstat[], int colstat[])> XPRSgetbasis =
+    nullptr;
+std::function<int(XPRSprob prob, const char* filename, const char* flags)>
+    XPRSwriteprob = nullptr;
+std::function<int(XPRSprob prob, char rowtype[], int first, int last)>
+    XPRSgetrowtype = nullptr;
+std::function<int(XPRSprob prob, char coltype[], int first, int last)>
+    XPRSgetcoltype = nullptr;
+std::function<int(XPRSprob prob, int nbounds, const int colind[],
+                  const char bndtype[], const double bndval[])>
+    XPRSchgbounds = nullptr;
+std::function<int(XPRSprob prob, int length, const double solval[],
+                  const int colind[], const char* name)>
+    XPRSaddmipsol = nullptr;
+std::function<int(XPRSprob prob, double x[], double slack[], double duals[],
+                  double djs[])>
+    XPRSgetlpsol = nullptr;
+std::function<int(XPRSprob prob, double x[], double slack[])> XPRSgetmipsol =
+    nullptr;
+std::function<int(XPRSprob prob, int ncols, const int colind[],
+                  const double objcoef[])>
+    XPRSchgobj = nullptr;
+std::function<int(XPRSprob prob, int row, int col, double coef)> XPRSchgcoef =
+    nullptr;
+std::function<int(XPRSprob prob, int ncoefs, const int rowind[],
+                  const int colind[], const double rowcoef[])>
+    XPRSchgmcoef = nullptr;
+std::function<int(XPRSprob prob, int nrows, const int rowind[],
+                  const double rhs[])>
+    XPRSchgrhs = nullptr;
+std::function<int(XPRSprob prob, int nrows, const int rowind[],
+                  const double rng[])>
+    XPRSchgrhsrange = nullptr;
+std::function<int(XPRSprob prob, int nrows, const int rowind[],
+                  const char rowtype[])>
+    XPRSchgrowtype = nullptr;
+std::function<int(
+    XPRSprob prob,
+    void(XPRS_CC* f_message)(XPRSprob cbprob, void* cbdata, const char* msg,
+                             int msglen, int msgtype),
+    void* p)>
+    XPRSsetcbmessage = nullptr;
 std::function<int(XPRSprob prob, const char* flags)> XPRSminim = nullptr;
 std::function<int(XPRSprob prob, const char* flags)> XPRSmaxim = nullptr;
 
@@ -102,15 +170,19 @@ absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
   xpress_dynamic_library->GetFunction(&XPRSlicense, "XPRSlicense");
   xpress_dynamic_library->GetFunction(&XPRSgetbanner, "XPRSgetbanner");
   xpress_dynamic_library->GetFunction(&XPRSgetversion, "XPRSgetversion");
-  xpress_dynamic_library->GetFunction(&XPRSsetdefaultcontrol, "XPRSsetdefaultcontrol");
+  xpress_dynamic_library->GetFunction(&XPRSsetdefaultcontrol,
+                                      "XPRSsetdefaultcontrol");
   xpress_dynamic_library->GetFunction(&XPRSsetintcontrol, "XPRSsetintcontrol");
-  xpress_dynamic_library->GetFunction(&XPRSsetintcontrol64, "XPRSsetintcontrol64");
+  xpress_dynamic_library->GetFunction(&XPRSsetintcontrol64,
+                                      "XPRSsetintcontrol64");
   xpress_dynamic_library->GetFunction(&XPRSsetdblcontrol, "XPRSsetdblcontrol");
   xpress_dynamic_library->GetFunction(&XPRSsetstrcontrol, "XPRSsetstrcontrol");
   xpress_dynamic_library->GetFunction(&XPRSgetintcontrol, "XPRSgetintcontrol");
-  xpress_dynamic_library->GetFunction(&XPRSgetintcontrol64, "XPRSgetintcontrol64");
+  xpress_dynamic_library->GetFunction(&XPRSgetintcontrol64,
+                                      "XPRSgetintcontrol64");
   xpress_dynamic_library->GetFunction(&XPRSgetdblcontrol, "XPRSgetdblcontrol");
-  xpress_dynamic_library->GetFunction(&XPRSgetstringcontrol, "XPRSgetstringcontrol");
+  xpress_dynamic_library->GetFunction(&XPRSgetstringcontrol,
+                                      "XPRSgetstringcontrol");
   xpress_dynamic_library->GetFunction(&XPRSgetintattrib, "XPRSgetintattrib");
   xpress_dynamic_library->GetFunction(&XPRSgetdblattrib, "XPRSgetdblattrib");
   xpress_dynamic_library->GetFunction(&XPRSloadlp, "XPRSloadlp");
@@ -152,9 +224,12 @@ absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
 
   auto notFound = xpress_dynamic_library->FunctionsNotFound();
   if (!notFound.empty()) {
-    return absl::NotFoundError(absl::StrCat("Could not find the following functions (list may not be exhaustive). [",
-                                            absl::StrJoin(notFound, "', '"),
-                                            "]. Please make sure that your XPRESS install is up-to-date (>= 8.13.0)."));
+    return absl::NotFoundError(
+        absl::StrCat("Could not find the following functions (list may not be "
+                     "exhaustive). [",
+                     absl::StrJoin(notFound, "', '"),
+                     "]. Please make sure that your XPRESS install is "
+                     "up-to-date (>= 8.13.0)."));
   }
   return absl::OkStatus();
 }
@@ -234,12 +309,12 @@ absl::Status LoadXpressDynamicLibrary(std::string& xpresspath) {
     }
 
     if (xpress_library.LibraryIsLoaded()) {
-      xpress_load_status =  LoadXpressFunctions(&xpress_library);
+      xpress_load_status = LoadXpressFunctions(&xpress_library);
     } else {
-      xpress_load_status = absl::NotFoundError(absl::StrCat(
-          "Could not find the Xpress shared library. Looked in: [",
-          absl::StrJoin(canonical_paths, "', '"),
-          "]. Please check environment variable XPRESSDIR"));
+      xpress_load_status = absl::NotFoundError(
+          absl::StrCat("Could not find the Xpress shared library. Looked in: [",
+                       absl::StrJoin(canonical_paths, "', '"),
+                       "]. Please check environment variable XPRESSDIR"));
     }
   });
   xpresspath.clear();
@@ -247,38 +322,33 @@ absl::Status LoadXpressDynamicLibrary(std::string& xpresspath) {
   return xpress_load_status;
 }
 
+void log_message_about_XPRSinit_argument(const char* xpress_from_env);
 /** init XPRESS environment */
 bool initXpressEnv(bool verbose, int xpress_oem_license_key) {
-  std::string xpresspath;
-  absl::Status status = LoadXpressDynamicLibrary(xpresspath);
+  std::string xpress_lib_dir;
+  absl::Status status = LoadXpressDynamicLibrary(xpress_lib_dir);
   if (!status.ok()) {
     LOG(WARNING) << status << "\n";
     return false;
   }
 
+  std::string xpauth_path;
   const char* xpress_from_env = getenv("XPRESS");
   if (xpress_from_env == nullptr) {
     if (verbose) {
-      LOG(WARNING)
-          << "XpressInterface Error : Environment variable XPRESS undefined.\n";
+      LOG(WARNING) << "XpressInterface Warning : Environment variable XPRESS "
+                      "undefined.\n";
     }
-    if (xpresspath.empty()) {
-      return false;
-    }
-  } else {
-    xpresspath = xpress_from_env;
   }
 
   int code;
-
   // if not an OEM key
   if (xpress_oem_license_key == 0) {
     if (verbose) {
-      LOG(WARNING) << "XpressInterface : Initialising xpress-MP with parameter "
-                   << xpresspath << "\n";
+      log_message_about_XPRSinit_argument(xpress_from_env);
     }
 
-    code = XPRSinit(xpresspath.c_str());
+    code = XPRSinit(xpress_from_env);
 
     if (!code) {
       // XPRSbanner informs about Xpress version, options and error messages
@@ -292,13 +362,21 @@ bool initXpressEnv(bool verbose, int xpress_oem_license_key) {
       }
       return true;
     } else {
-      LOG(ERROR) << "XpressInterface: Xpress found at " << xpresspath << "\n";
+      LOG(ERROR) << "XpressInterface: Xpress found at " << xpress_lib_dir
+                 << "\n";
       char errmsg[256];
       XPRSgetlicerrmsg(errmsg, 256);
 
-      LOG(ERROR) << "XpressInterface : License error : " << errmsg
-                 << " (XPRSinit returned code " << code << "). Please check"
-                 << " environment variable XPRESS.\n";
+      LOG(ERROR)
+          << "XpressInterface : License error : " << errmsg
+          << " (XPRSinit returned code " << code << "). \n";
+      LOG(ERROR)
+          << "|_Your Xpress installation should have set the env var XPAUTH_PATH"
+             " to the full path of your licence file\n";
+      LOG(ERROR)
+          << "|_You can alternatively set the XPRESS environment variable"
+             " to set the directory of the xpauth.xpr licence file\n"
+          << ".\n";
 
       return false;
     }
@@ -349,6 +427,16 @@ bool initXpressEnv(bool verbose, int xpress_oem_license_key) {
       return false;
     }
   }
+}
+void log_message_about_XPRSinit_argument(const char* xpress_from_env) {
+  std::string XPRSinit_arg_msg;
+  if (xpress_from_env == nullptr) {
+    XPRSinit_arg_msg = "\"nullptr\", env var XPAUTH_PATH is used";
+  } else {
+    XPRSinit_arg_msg = xpress_from_env;
+  }
+  LOG(WARNING) << "XpressInterface : Initialising xpress-MP with parameter "
+               << XPRSinit_arg_msg << "\n";
 }
 
 bool XpressIsCorrectlyInstalled() {

--- a/ortools/xpress/environment.cc
+++ b/ortools/xpress/environment.cc
@@ -42,118 +42,50 @@ std::function<int(int* p_i, char* p_c)> XPRSlicense = nullptr;
 std::function<int(char* banner)> XPRSgetbanner = nullptr;
 std::function<int(char* version)> XPRSgetversion = nullptr;
 std::function<int(XPRSprob prob, int control)> XPRSsetdefaultcontrol = nullptr;
-std::function<int(XPRSprob prob, int control, int value)> XPRSsetintcontrol =
-    nullptr;
-std::function<int(XPRSprob prob, int control, XPRSint64 value)>
-    XPRSsetintcontrol64 = nullptr;
-std::function<int(XPRSprob prob, int control, double value)> XPRSsetdblcontrol =
-    nullptr;
-std::function<int(XPRSprob prob, int control, const char* value)>
-    XPRSsetstrcontrol = nullptr;
-std::function<int(XPRSprob prob, int control, int* p_value)> XPRSgetintcontrol =
-    nullptr;
-std::function<int(XPRSprob prob, int control, XPRSint64* p_value)>
-    XPRSgetintcontrol64 = nullptr;
-std::function<int(XPRSprob prob, int control, double* p_value)>
-    XPRSgetdblcontrol = nullptr;
-std::function<int(XPRSprob prob, int control, char* value, int maxbytes,
-                  int* p_nbytes)>
-    XPRSgetstringcontrol = nullptr;
-std::function<int(XPRSprob prob, int attrib, int* p_value)> XPRSgetintattrib =
-    nullptr;
-std::function<int(XPRSprob prob, int attrib, double* p_value)>
-    XPRSgetdblattrib = nullptr;
-std::function<int(XPRSprob prob, const char* probname, int ncols, int nrows,
-                  const char rowtype[], const double rhs[], const double rng[],
-                  const double objcoef[], const int start[], const int collen[],
-                  const int rowind[], const double rowcoef[], const double lb[],
-                  const double ub[])>
-    XPRSloadlp = nullptr;
-std::function<int(XPRSprob prob, const char* probname, int ncols, int nrows,
-                  const char rowtype[], const double rhs[], const double rng[],
-                  const double objcoef[], const XPRSint64 start[],
-                  const int collen[], const int rowind[],
-                  const double rowcoef[], const double lb[], const double ub[])>
-    XPRSloadlp64 = nullptr;
-std::function<int(XPRSprob prob, double objcoef[], int first, int last)>
-    XPRSgetobj = nullptr;
-std::function<int(XPRSprob prob, double rhs[], int first, int last)>
-    XPRSgetrhs = nullptr;
-std::function<int(XPRSprob prob, double rng[], int first, int last)>
-    XPRSgetrhsrange = nullptr;
-std::function<int(XPRSprob prob, double lb[], int first, int last)> XPRSgetlb =
-    nullptr;
-std::function<int(XPRSprob prob, double ub[], int first, int last)> XPRSgetub =
-    nullptr;
-std::function<int(XPRSprob prob, int row, int col, double* p_coef)>
-    XPRSgetcoef = nullptr;
-std::function<int(XPRSprob prob, int nrows, int ncoefs, const char rowtype[],
-                  const double rhs[], const double rng[], const int start[],
-                  const int colind[], const double rowcoef[])>
-    XPRSaddrows = nullptr;
-std::function<int(XPRSprob prob, int nrows, const int rowind[])> XPRSdelrows =
-    nullptr;
-std::function<int(XPRSprob prob, int ncols, int ncoefs, const double objcoef[],
-                  const int start[], const int rowind[], const double rowcoef[],
-                  const double lb[], const double ub[])>
-    XPRSaddcols = nullptr;
-std::function<int(XPRSprob prob, int type, const char names[], int first,
-                  int last)>
-    XPRSaddnames = nullptr;
-std::function<int(XPRSprob prob, int type, char names[], int first, int last)>
-    XPRSgetnames = nullptr;
-std::function<int(XPRSprob prob, int ncols, const int colind[])> XPRSdelcols =
-    nullptr;
-std::function<int(XPRSprob prob, int ncols, const int colind[],
-                  const char coltype[])>
-    XPRSchgcoltype = nullptr;
-std::function<int(XPRSprob prob, const int rowstat[], const int colstat[])>
-    XPRSloadbasis = nullptr;
+std::function<int(XPRSprob prob, int control, int value)> XPRSsetintcontrol = nullptr;
+std::function<int(XPRSprob prob, int control, XPRSint64 value)> XPRSsetintcontrol64 = nullptr;
+std::function<int(XPRSprob prob, int control, double value)> XPRSsetdblcontrol = nullptr;
+std::function<int(XPRSprob prob, int control, const char* value)> XPRSsetstrcontrol = nullptr;
+std::function<int(XPRSprob prob, int control, int* p_value)> XPRSgetintcontrol = nullptr;
+std::function<int(XPRSprob prob, int control, XPRSint64* p_value)> XPRSgetintcontrol64 = nullptr;
+std::function<int(XPRSprob prob, int control, double* p_value)> XPRSgetdblcontrol = nullptr;
+std::function<int(XPRSprob prob, int control, char* value, int maxbytes, int* p_nbytes)> XPRSgetstringcontrol = nullptr;
+std::function<int(XPRSprob prob, int attrib, int* p_value)> XPRSgetintattrib = nullptr;
+std::function<int(XPRSprob prob, int attrib, double* p_value)> XPRSgetdblattrib = nullptr;
+std::function<int(XPRSprob prob, const char* probname, int ncols, int nrows, const char rowtype[], const double rhs[], const double rng[], const double objcoef[], const int start[], const int collen[], const int rowind[], const double rowcoef[], const double lb[], const double ub[])> XPRSloadlp = nullptr;
+std::function<int(XPRSprob prob, const char* probname, int ncols, int nrows, const char rowtype[], const double rhs[], const double rng[], const double objcoef[], const XPRSint64 start[], const int collen[], const int rowind[], const double rowcoef[], const double lb[], const double ub[])> XPRSloadlp64 = nullptr;
+std::function<int(XPRSprob prob, double objcoef[], int first, int last)> XPRSgetobj = nullptr;
+std::function<int(XPRSprob prob, double rhs[], int first, int last)> XPRSgetrhs = nullptr;
+std::function<int(XPRSprob prob, double rng[], int first, int last)> XPRSgetrhsrange = nullptr;
+std::function<int(XPRSprob prob, double lb[], int first, int last)> XPRSgetlb = nullptr;
+std::function<int(XPRSprob prob, double ub[], int first, int last)> XPRSgetub = nullptr;
+std::function<int(XPRSprob prob, int row, int col, double* p_coef)> XPRSgetcoef = nullptr;
+std::function<int(XPRSprob prob, int nrows, int ncoefs, const char rowtype[], const double rhs[], const double rng[], const int start[], const int colind[], const double rowcoef[])> XPRSaddrows = nullptr;
+std::function<int(XPRSprob prob, int nrows, const int rowind[])> XPRSdelrows = nullptr;
+std::function<int(XPRSprob prob, int ncols, int ncoefs, const double objcoef[], const int start[], const int rowind[], const double rowcoef[], const double lb[], const double ub[])> XPRSaddcols = nullptr;
+std::function<int(XPRSprob prob, int type, const char names[], int first, int last)> XPRSaddnames = nullptr;
+std::function<int(XPRSprob prob, int type, char names[], int first, int last)> XPRSgetnames = nullptr;
+std::function<int(XPRSprob prob, int ncols, const int colind[])> XPRSdelcols = nullptr;
+std::function<int(XPRSprob prob, int ncols, const int colind[], const char coltype[])> XPRSchgcoltype = nullptr;
+std::function<int(XPRSprob prob, const int rowstat[], const int colstat[])> XPRSloadbasis = nullptr;
 std::function<int(XPRSprob prob)> XPRSpostsolve = nullptr;
 std::function<int(XPRSprob prob, int objsense)> XPRSchgobjsense = nullptr;
 std::function<int(XPRSprob prob, char* errmsg)> XPRSgetlasterror = nullptr;
-std::function<int(XPRSprob prob, int rowstat[], int colstat[])> XPRSgetbasis =
-    nullptr;
-std::function<int(XPRSprob prob, const char* filename, const char* flags)>
-    XPRSwriteprob = nullptr;
-std::function<int(XPRSprob prob, char rowtype[], int first, int last)>
-    XPRSgetrowtype = nullptr;
-std::function<int(XPRSprob prob, char coltype[], int first, int last)>
-    XPRSgetcoltype = nullptr;
-std::function<int(XPRSprob prob, int nbounds, const int colind[],
-                  const char bndtype[], const double bndval[])>
-    XPRSchgbounds = nullptr;
-std::function<int(XPRSprob prob, int length, const double solval[],
-                  const int colind[], const char* name)>
-    XPRSaddmipsol = nullptr;
-std::function<int(XPRSprob prob, double x[], double slack[], double duals[],
-                  double djs[])>
-    XPRSgetlpsol = nullptr;
-std::function<int(XPRSprob prob, double x[], double slack[])> XPRSgetmipsol =
-    nullptr;
-std::function<int(XPRSprob prob, int ncols, const int colind[],
-                  const double objcoef[])>
-    XPRSchgobj = nullptr;
-std::function<int(XPRSprob prob, int row, int col, double coef)> XPRSchgcoef =
-    nullptr;
-std::function<int(XPRSprob prob, int ncoefs, const int rowind[],
-                  const int colind[], const double rowcoef[])>
-    XPRSchgmcoef = nullptr;
-std::function<int(XPRSprob prob, int nrows, const int rowind[],
-                  const double rhs[])>
-    XPRSchgrhs = nullptr;
-std::function<int(XPRSprob prob, int nrows, const int rowind[],
-                  const double rng[])>
-    XPRSchgrhsrange = nullptr;
-std::function<int(XPRSprob prob, int nrows, const int rowind[],
-                  const char rowtype[])>
-    XPRSchgrowtype = nullptr;
-std::function<int(
-    XPRSprob prob,
-    void(XPRS_CC* f_message)(XPRSprob cbprob, void* cbdata, const char* msg,
-                             int msglen, int msgtype),
-    void* p)>
-    XPRSsetcbmessage = nullptr;
+std::function<int(XPRSprob prob, int rowstat[], int colstat[])> XPRSgetbasis = nullptr;
+std::function<int(XPRSprob prob, const char* filename, const char* flags)> XPRSwriteprob = nullptr;
+std::function<int(XPRSprob prob, char rowtype[], int first, int last)> XPRSgetrowtype = nullptr;
+std::function<int(XPRSprob prob, char coltype[], int first, int last)> XPRSgetcoltype = nullptr;
+std::function<int(XPRSprob prob, int nbounds, const int colind[], const char bndtype[], const double bndval[])> XPRSchgbounds = nullptr;
+std::function<int(XPRSprob prob, int length, const double solval[], const int colind[], const char* name)> XPRSaddmipsol = nullptr;
+std::function<int(XPRSprob prob, double x[], double slack[], double duals[], double djs[])> XPRSgetlpsol = nullptr;
+std::function<int(XPRSprob prob, double x[], double slack[])> XPRSgetmipsol = nullptr;
+std::function<int(XPRSprob prob, int ncols, const int colind[], const double objcoef[])> XPRSchgobj = nullptr;
+std::function<int(XPRSprob prob, int row, int col, double coef)> XPRSchgcoef = nullptr;
+std::function<int(XPRSprob prob, int ncoefs, const int rowind[], const int colind[], const double rowcoef[])> XPRSchgmcoef = nullptr;
+std::function<int(XPRSprob prob, int nrows, const int rowind[], const double rhs[])> XPRSchgrhs = nullptr;
+std::function<int(XPRSprob prob, int nrows, const int rowind[], const double rng[])> XPRSchgrhsrange = nullptr;
+std::function<int(XPRSprob prob, int nrows, const int rowind[], const char rowtype[])> XPRSchgrowtype = nullptr;
+std::function<int(XPRSprob prob, void (XPRS_CC *f_message)(XPRSprob cbprob, void* cbdata, const char* msg, int msglen, int msgtype), void* p)> XPRSsetcbmessage = nullptr;
 std::function<int(XPRSprob prob, const char* flags)> XPRSminim = nullptr;
 std::function<int(XPRSprob prob, const char* flags)> XPRSmaxim = nullptr;
 
@@ -170,19 +102,15 @@ absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
   xpress_dynamic_library->GetFunction(&XPRSlicense, "XPRSlicense");
   xpress_dynamic_library->GetFunction(&XPRSgetbanner, "XPRSgetbanner");
   xpress_dynamic_library->GetFunction(&XPRSgetversion, "XPRSgetversion");
-  xpress_dynamic_library->GetFunction(&XPRSsetdefaultcontrol,
-                                      "XPRSsetdefaultcontrol");
+  xpress_dynamic_library->GetFunction(&XPRSsetdefaultcontrol, "XPRSsetdefaultcontrol");
   xpress_dynamic_library->GetFunction(&XPRSsetintcontrol, "XPRSsetintcontrol");
-  xpress_dynamic_library->GetFunction(&XPRSsetintcontrol64,
-                                      "XPRSsetintcontrol64");
+  xpress_dynamic_library->GetFunction(&XPRSsetintcontrol64, "XPRSsetintcontrol64");
   xpress_dynamic_library->GetFunction(&XPRSsetdblcontrol, "XPRSsetdblcontrol");
   xpress_dynamic_library->GetFunction(&XPRSsetstrcontrol, "XPRSsetstrcontrol");
   xpress_dynamic_library->GetFunction(&XPRSgetintcontrol, "XPRSgetintcontrol");
-  xpress_dynamic_library->GetFunction(&XPRSgetintcontrol64,
-                                      "XPRSgetintcontrol64");
+  xpress_dynamic_library->GetFunction(&XPRSgetintcontrol64, "XPRSgetintcontrol64");
   xpress_dynamic_library->GetFunction(&XPRSgetdblcontrol, "XPRSgetdblcontrol");
-  xpress_dynamic_library->GetFunction(&XPRSgetstringcontrol,
-                                      "XPRSgetstringcontrol");
+  xpress_dynamic_library->GetFunction(&XPRSgetstringcontrol, "XPRSgetstringcontrol");
   xpress_dynamic_library->GetFunction(&XPRSgetintattrib, "XPRSgetintattrib");
   xpress_dynamic_library->GetFunction(&XPRSgetdblattrib, "XPRSgetdblattrib");
   xpress_dynamic_library->GetFunction(&XPRSloadlp, "XPRSloadlp");
@@ -224,12 +152,9 @@ absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
 
   auto notFound = xpress_dynamic_library->FunctionsNotFound();
   if (!notFound.empty()) {
-    return absl::NotFoundError(
-        absl::StrCat("Could not find the following functions (list may not be "
-                     "exhaustive). [",
-                     absl::StrJoin(notFound, "', '"),
-                     "]. Please make sure that your XPRESS install is "
-                     "up-to-date (>= 8.13.0)."));
+    return absl::NotFoundError(absl::StrCat("Could not find the following functions (list may not be exhaustive). [",
+                                            absl::StrJoin(notFound, "', '"),
+                                            "]. Please make sure that your XPRESS install is up-to-date (>= 8.13.0)."));
   }
   return absl::OkStatus();
 }

--- a/ortools/xpress/environment.cc
+++ b/ortools/xpress/environment.cc
@@ -280,7 +280,6 @@ bool initXpressEnv(bool verbose, int xpress_oem_license_key) {
       return true;
     } else {
       log_full_license_error(code, xpress_lib_dir);
-
       return false;
     }
   } else {


### PR DESCRIPTION
This should close #78
It is now possible to load the xpress library as 
according to the instructions in the FICO Xpress READMEs:
setting the xpress variables using the script `xpvars.sh`

The function `XPRSinit(xpress_from_env);` is called with a `nullptr` parameter (as suggested in the documentation.
This shoul point xpress to look for the licence file using the (standard) `XPAUTH_PATH` environment variable.

We don't use anymore the `XPRESS` environment variable.

Users of Xpress should set the Xpress environment variables using  the script `xpvars.sh` provided by the xpress installation