### PR TITLE
Install Xpress with pip in Workflows

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -73,19 +73,18 @@ jobs:
         run: |
           git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${BRANCH_NAME} .
 
-      - name: Checkout Xpress linux
-        uses: actions/checkout@v2
-        with:
-          repository: rte-france/xpress-mp
-          path: ${{ env.XPRESS_INSTALL_DIR }}
-          ref: "9.0"
-          token: ${{ secrets.ACCESS_TOKEN }}
-
-      - name: set Xpress variables
+      - name: Set up Python
         run: |
-          cd ${{ env.XPRESS_INSTALL_DIR }}
-          echo "XPRESSDIR=$PWD" >> $GITHUB_ENV
-          echo "XPAUTH_PATH=$PWD/bin/xpauth.xpr" >> $GITHUB_ENV
+          yum update -y
+          yum install -y python3
+          python3 --version
+
+      - name: Set-up Xpress with pip
+        run: |
+          python3 -m pip install xpress==8.13.8
+          XPRESS_DIR=/usr/local/lib64/python3.6/site-packages/xpress
+          echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
 
       - name: Download Sirius
         if : ${{ matrix.sirius == 'ON' }}

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -73,18 +73,19 @@ jobs:
         run: |
           git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${BRANCH_NAME} .
 
-      - name: Set up Python
-        run: |
-          yum update -y
-          yum install -y python3
-          python3 --version
+      - name: Checkout Xpress linux
+        uses: actions/checkout@v2
+        with:
+          repository: rte-france/xpress-mp
+          path: ${{ env.XPRESS_INSTALL_DIR }}
+          ref: "9.0"
+          token: ${{ secrets.ACCESS_TOKEN }}
 
-      - name: Set-up Xpress with pip
+      - name: set Xpress variables
         run: |
-          python3 -m pip install xpress==8.13.8
-          XPRESS_DIR=/usr/local/lib64/python3.6/site-packages/xpress
-          echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
-          echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
+          cd ${{ env.XPRESS_INSTALL_DIR }}
+          echo "XPRESSDIR=$PWD" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=$PWD/bin/xpauth.xpr" >> $GITHUB_ENV
 
       - name: Download Sirius
         if : ${{ matrix.sirius == 'ON' }}

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -113,9 +113,10 @@ jobs:
       - name: Set-up Xpress with pip
         run: |
           python3 -m pip install xpress==9.0.0
-          XPRESS_DIR=/usr/local/lib64/python3.6/site-packages/xpress
+          XPRESS_DIR=/usr/local/lib64/python3.9/site-packages/xpress
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
+          ln -s $XPRESS_DIR/lib/libxprs.so.41 $XPRESS_DIR/lib/libxprs.so
 
       - name: Configure OR-Tools
         run: |

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
       - feature/*
       - merge*
       - fix/*

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
       - feature/*
       - merge*
       - fix/*

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -111,19 +111,18 @@ jobs:
         run: |
           git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git -b ${BRANCH_NAME} .
 
-      - name: Checkout Xpress linux
-        uses: actions/checkout@v2
-        with:
-          repository: rte-france/xpress-mp
-          path: ${{ env.XPRESS_INSTALL_DIR }}
-          ref: "9.0"
-          token: ${{ secrets.ACCESS_TOKEN }}
-
-      - name: set Xpress variables
+      - name: Set-up Xpress with pip
         run: |
-          cd ${{ env.XPRESS_INSTALL_DIR }}
-          echo "XPRESSDIR=$PWD" >> $GITHUB_ENV
-          echo "XPAUTH_PATH=$PWD/bin/xpauth.xpr" >> $GITHUB_ENV
+          python3 -m pip install xpress==8.13.8
+          XPRESS_DIR=/usr/local/lib64/python3.6/site-packages/xpress
+          echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
+
+      - name: Check variables
+        run: |
+          echo $XPRESSDIR
+          echo $XPAUTH_PATH
+          ls -l $XPAUTH_PATH
 
       - name: Configure OR-Tools
         run: |

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           export PATH=/root/.local/bin:$PATH
           dnf -y update
-          dnf -y install python3 python3-devel python3-pip
+          dnf -y install python39 python39-devel python39-pip
           dnf clean all
           echo "/root/.local/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -94,7 +94,6 @@ jobs:
           dnf clean all
           rm -rf /var/cache/dnf
       - name: Install python
-        if: ${{ matrix.python == 'ON' }}
         run: |
           export PATH=/root/.local/bin:$PATH
           dnf -y update
@@ -117,12 +116,6 @@ jobs:
           XPRESS_DIR=/usr/local/lib64/python3.6/site-packages/xpress
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
-
-      - name: Check variables
-        run: |
-          echo $XPRESSDIR
-          echo $XPAUTH_PATH
-          ls -l $XPAUTH_PATH
 
       - name: Configure OR-Tools
         run: |

--- a/.github/workflows/oracle.yml
+++ b/.github/workflows/oracle.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Set-up Xpress with pip
         run: |
-          python3 -m pip install xpress==8.13.8
+          python3 -m pip install xpress==9.0.0
           XPRESS_DIR=/usr/local/lib64/python3.6/site-packages/xpress
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV

--- a/.github/workflows/setup-env/action.yml
+++ b/.github/workflows/setup-env/action.yml
@@ -1,4 +1,4 @@
-name: "setup ubuntu environement"
+name: "setup ubuntu environment"
 description: "setup dotnet python and compile sirius"
 inputs:
   os:
@@ -34,7 +34,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install mypy-protobuf absl-py setuptools wheel numpy pandas virtualenv
+        python -m pip install mypy-protobuf absl-py setuptools wheel numpy pandas virtualenv xpress
 
     - name: Install SWIG 4.0.2 for windows
       if: ${{ startsWith(inputs.os, 'windows') }}

--- a/.github/workflows/setup-env/action.yml
+++ b/.github/workflows/setup-env/action.yml
@@ -34,7 +34,7 @@ runs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        python -m pip install mypy-protobuf absl-py setuptools wheel numpy pandas virtualenv xpress
+        python -m pip install mypy-protobuf absl-py setuptools wheel numpy pandas virtualenv
 
     - name: Install SWIG 4.0.2 for windows
       if: ${{ startsWith(inputs.os, 'windows') }}

--- a/.github/workflows/ubuntu-windows.yml
+++ b/.github/workflows/ubuntu-windows.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SIRIUS_RELEASE_TAG: ${{ matrix.sirius-release-tag }}
-      XPRESSDIR: ${{ github.workspace }}/xpressmp
-      XPAUTH_PATH: ${{ github.workspace }}/xpressmp/bin/xpauth.xpr
+      XPRESSDIR: ${{ github.workspace }}/xpress
+      XPAUTH_PATH: ${{ github.workspace }}/xpress/bin/xpauth.xpr
       SIRIUS_INSTALL_PATH : ${{ github.workspace }}/sirius_install
       SIRIUS: ${{ github.workspace }}/sirius_install/bin
     strategy:
@@ -169,22 +169,31 @@ jobs:
           unzip $zipfile
           mv "${{ matrix.os }}_sirius-solver-install" "${{ env.SIRIUS_INSTALL_PATH }}"
 
-      - name: Checkout Xpress linux
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        uses: actions/checkout@v2
-        with:
-          repository: rte-france/xpress-mp
-          path: ${{ env.XPRESSDIR }}
-          ref: "9.0"
-          token: ${{ secrets.ACCESS_TOKEN }}
-      - name: Checkout Xpress windows
-        if: ${{ startsWith(matrix.os, 'windows') }}
-        uses: actions/checkout@v2
-        with:
-          repository: rte-france/xpress-mp-temp
-          path: ${{ env.XPRESSDIR }}
-          ref: "9.0"
-          token: ${{ secrets.ACCESS_TOKEN }}
+      - name: Set-up Xpress with pip
+        run: |
+          python -m pip install xpress==9.0.0
+          ls ${{ github.workspace }}/Python
+        #  cd $RUNNER_TOOL_CACHE/Python/3.10/lib/python3.10/site-packages/xpress
+        #  mkdir bin
+        #  cp path/to/xpauth.xpr bin/xpauth.xpr
+        #  ln -s lib/libxprs.so.41 lib/libxprs.so
+
+      # - name: Checkout Xpress linux
+      #   if: ${{ startsWith(matrix.os, 'ubuntu') }}
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: rte-france/xpress-mp
+      #     path: ${{ env.XPRESSDIR }}
+      #     ref: "9.0"
+      #     token: ${{ secrets.ACCESS_TOKEN }}
+      # - name: Checkout Xpress windows
+      #   if: ${{ startsWith(matrix.os, 'windows') }}
+      #   uses: actions/checkout@v2
+      #   with:
+      #     repository: rte-france/xpress-mp-temp
+      #     path: ${{ env.XPRESSDIR }}
+      #     ref: "9.0"
+      #     token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: set cache variables
         id: cache

--- a/.github/workflows/ubuntu-windows.yml
+++ b/.github/workflows/ubuntu-windows.yml
@@ -182,7 +182,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'windows') }}
         shell: bash
         run: |
-          python -m pip install xpress==9.0.0
+          python -m pip install --no-cache-dir xpress==9.0.0
           XPRESS_DIR="${{ env.pythonLocation }}\Lib\site-packages\xpress"
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR\license\community-xpauth.xpr" >> $GITHUB_ENV

--- a/.github/workflows/ubuntu-windows.yml
+++ b/.github/workflows/ubuntu-windows.yml
@@ -167,14 +167,25 @@ jobs:
           unzip $zipfile
           mv "${{ matrix.os }}_sirius-solver-install" "${{ env.SIRIUS_INSTALL_PATH }}"
 
-      - name: Set-up Xpress with pip
+      - name: Set-up Xpress with pip for Ubuntu
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         shell: bash
         run: |
           python -m pip install xpress==9.0.0
-          XPRESS_DIR=${{ env.pythonLocation }}/../lib/python${{ matrix.python-version }}/site-packages/xpress
+          XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ matrix.python-version }}/site-packages/xpress
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
+          echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
           ln -s $XPRESS_DIR/lib/libxprs.so.41 $XPRESS_DIR/lib/libxprs.so
+
+      - name: Set-up Xpress with pip for Windows
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        shell: bash
+        run: |
+          python -m pip install xpress==9.0.0
+          XPRESS_DIR="${{ env.pythonLocation }}\Lib\site-packages\xpress"
+          echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=$XPRESS_DIR\license\community-xpauth.xpr" >> $GITHUB_ENV
 
       - name: set cache variables
         id: cache

--- a/.github/workflows/ubuntu-windows.yml
+++ b/.github/workflows/ubuntu-windows.yml
@@ -19,8 +19,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SIRIUS_RELEASE_TAG: ${{ matrix.sirius-release-tag }}
-      XPRESSDIR: ${{ github.workspace }}/xpress
-      XPAUTH_PATH: ${{ github.workspace }}/xpress/bin/xpauth.xpr
       SIRIUS_INSTALL_PATH : ${{ github.workspace }}/sirius_install
       SIRIUS: ${{ github.workspace }}/sirius_install/bin
     strategy:
@@ -170,30 +168,13 @@ jobs:
           mv "${{ matrix.os }}_sirius-solver-install" "${{ env.SIRIUS_INSTALL_PATH }}"
 
       - name: Set-up Xpress with pip
+        shell: bash
         run: |
           python -m pip install xpress==9.0.0
-          ls ${{ github.workspace }}/Python
-        #  cd $RUNNER_TOOL_CACHE/Python/3.10/lib/python3.10/site-packages/xpress
-        #  mkdir bin
-        #  cp path/to/xpauth.xpr bin/xpauth.xpr
-        #  ln -s lib/libxprs.so.41 lib/libxprs.so
-
-      # - name: Checkout Xpress linux
-      #   if: ${{ startsWith(matrix.os, 'ubuntu') }}
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: rte-france/xpress-mp
-      #     path: ${{ env.XPRESSDIR }}
-      #     ref: "9.0"
-      #     token: ${{ secrets.ACCESS_TOKEN }}
-      # - name: Checkout Xpress windows
-      #   if: ${{ startsWith(matrix.os, 'windows') }}
-      #   uses: actions/checkout@v2
-      #   with:
-      #     repository: rte-france/xpress-mp-temp
-      #     path: ${{ env.XPRESSDIR }}
-      #     ref: "9.0"
-      #     token: ${{ secrets.ACCESS_TOKEN }}
+          XPRESS_DIR=${{ env.pythonLocation }}/../lib/python${{ matrix.python-version }}/site-packages/xpress
+          echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
+          ln -s $XPRESS_DIR/lib/libxprs.so.41 $XPRESS_DIR/lib/libxprs.so
 
       - name: set cache variables
         id: cache


### PR DESCRIPTION
The GitHub actions now automatically retrieve Xpress by installing the Python package with `pip install xpress`. Depending on the OS, different versions of Xpress are supported:
- **CentOS**: Xpress `8.13.8` on Python 3.6
- **Oracle**: Xpress `9.0.0` on Python 3.9
- **Ubuntu**: Xpress `9.0.0` on Python 3.10
- **Windows**: Xpress `9.0.0` on Python 3.10