### PR TITLE
relax conditions of double equality

### DIFF
--- a/ortools/linear_solver/unittests/xpress_interface.cc
+++ b/ortools/linear_solver/unittests/xpress_interface.cc
@@ -1244,9 +1244,10 @@ ENDATA
     EXPECT_GT(nSolutions, 5);
     // Test variable values for the last solution found
     for (int i = 0; i < solver.NumVariables(); ++i) {
-      EXPECT_DOUBLE_EQ(myMpCallback->getLastVariableValue(i),
+      EXPECT_NEAR(myMpCallback->getLastVariableValue(i),
                        solver.LookupVariableOrNull("x_" + std::to_string(i))
-                           ->solution_value());
+                           ->solution_value(),
+                  1e-10);
     }
   }
 


### PR DESCRIPTION
it looks like one of our test can fail for differences as little as 1e-15 and this causes the test to fail.
I propose to change the assertion to `EXPECT_NEAR` instead, with a tolerance of 1e-10
