### PR TITLE
revert names

### DIFF
--- a/ortools/linear_solver/unittests/xpress_interface.cc
+++ b/ortools/linear_solver/unittests/xpress_interface.cc
@@ -30,11 +30,6 @@ namespace operations_research {
       return cols;
     }
 
-    std::string getRowName(int n) {
-      EXPECT_LT(n, getNumConstraints());
-      return getName(n, XPRS_NAMES_ROW);
-    }
-
     double getLb(int n) {
       EXPECT_LT(n, getNumVariables());
       double lb;
@@ -47,11 +42,6 @@ namespace operations_research {
       double ub;
       EXPECT_STATUS(XPRSgetub(prob(), &ub, n, n));
       return ub;
-    }
-
-    std::string getColName(int n) {
-      EXPECT_LT(n, getNumVariables());
-      return getName(n, XPRS_NAMES_COLUMN);
     }
 
     char getVariableType(int n) {
@@ -142,23 +132,6 @@ namespace operations_research {
       return (XPRSprob)solver_->underlying_solver();
     }
 
-    std::string getName(int n, int type) {
-      int namelength;
-      EXPECT_STATUS(XPRSgetintattrib(prob(), XPRS_NAMELENGTH, &namelength));
-
-      std::string name;
-      name.resize(8 * namelength + 1);
-      EXPECT_STATUS(XPRSgetnames(prob(), type, name.data(), n, n));
-
-      name.erase(std::find_if(name.rbegin(), name.rend(),
-                              [](unsigned char ch) {
-                                return !std::isspace(ch) && ch != '\0';
-                              })
-                     .base(),
-                 name.end());
-
-      return name;
-    }
   };
 
 #define UNITTEST_INIT_MIP() \
@@ -281,18 +254,7 @@ namespace operations_research {
     EXPECT_EQ(getter.getNumVariables(), 502);
   }
   
-  TEST(XpressInterface, VariablesName) {
-    UNITTEST_INIT_MIP();
-    solver.MakeRowConstraint(-solver.infinity(), 0);
 
-    std::string pi("Pi");
-    std::string secondVar("Name");
-    MPVariable* x1 = solver.MakeNumVar(-1., 5.1, pi);
-    MPVariable* x2 = solver.MakeNumVar(3.14, 5.1, secondVar);
-    solver.Solve();
-    EXPECT_EQ(getter.getColName(0), pi);
-    EXPECT_EQ(getter.getColName(1), secondVar);
-  }
 
   TEST(XpressInterface, NumConstraints) {
     UNITTEST_INIT_MIP();
@@ -301,18 +263,6 @@ namespace operations_research {
     solver.MakeRowConstraint(12.1, 1000.0);
     solver.Solve();
     EXPECT_EQ(getter.getNumConstraints(), 3);
-  }
-
-  TEST(XpressInterface, ConstraintName) {
-    UNITTEST_INIT_MIP();
-
-    std::string phi("Phi");
-    std::string otherCnt("constraintName");
-    solver.MakeRowConstraint(100.0, 100.0, phi);
-    solver.MakeRowConstraint(-solver.infinity(), 13.1, otherCnt);
-    solver.Solve();
-    EXPECT_EQ(getter.getRowName(0), phi);
-    EXPECT_EQ(getter.getRowName(1), otherCnt);
   }
 
   TEST(XpressInterface, Reset) {

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1338,13 +1338,15 @@ void XpressInterface::ExtractNewVariables() {
             }
           }
           --cmatbeg;
-          CHECK_STATUS(XPRSaddcols(mLp, new_col_count, nonzeros, obj.get(), cmatbeg,
-                                   cmatind.get(), cmatval.get(), lb.get(),
-                                   ub.get()));
-          if (have_names) {
-            CHECK_STATUS(XPRSaddnames(mLp, XPRS_NAMES_COLUMN, col_names.data(),
-                                      0, new_col_count - 1));
-          }
+          CHECK_STATUS(XPRSaddcols(mLp, new_col_count, nonzeros, obj.get(),
+                                   cmatbeg, cmatind.get(), cmatval.get(),
+                                   lb.get(), ub.get()));
+          // TODO Fixme
+          // Writing all names worsen the performance significantly
+          // Performance are //if (have_names) {
+          //  CHECK_STATUS(XPRSaddnames(mLp, XPRS_NAMES_COLUMN, col_names.data(),
+          //                            0, new_col_count - 1));
+          //}
         }
       }
 
@@ -1359,13 +1361,15 @@ void XpressInterface::ExtractNewVariables() {
         cmatind[0] = 0;
         cmatval[0] = 1.0;
 
-        CHECK_STATUS(XPRSaddcols(mLp, new_col_count, 0, obj.get(), cmatbeg.data(),
-                                 cmatind.get(), cmatval.get(), lb.get(),
-                                 ub.get()));
-        if (have_names) {
-          CHECK_STATUS(XPRSaddnames(mLp, XPRS_NAMES_COLUMN, col_names.data(), 0,
-                                    new_col_count - 1));
-        }
+        CHECK_STATUS(XPRSaddcols(mLp, new_col_count, 0, obj.get(),
+                                 cmatbeg.data(), cmatind.get(), cmatval.get(),
+                                 lb.get(), ub.get()));
+        //TODO fixme
+        // Writing all names worsen the performance significantly
+        //if (have_names) {
+        //  CHECK_STATUS(XPRSaddnames(mLp, XPRS_NAMES_COLUMN, col_names.data(), 0,
+        //                            new_col_count - 1));
+        //}
         int const cols = getnumcols(mLp);
         unique_ptr<int[]> ind(new int[new_col_count]);
         for (int j = 0; j < cols; ++j) ind[j] = j;


### PR DESCRIPTION
I simply commented out the code responsible for writing the names of the variables and of the constraints for Xpress.
I also removed the unit tests associated with the two features