### PR TITLE
use XPRSmipoptimize and XPRSlpoptimize instead of XPRSminim and XPRSmaxim

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1912,10 +1912,10 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
 
   int xpress_stat = 0;
   if (mMip) {
-    status = XPRSmipoptimize(mLp, "g");
+    status = XPRSmipoptimize(mLp,"");
     XPRSgetintattrib(mLp, XPRS_MIPSTATUS, &xpress_stat);
   } else {
-    status = XPRSlpoptimize(mLp, "g");
+    status = XPRSlpoptimize(mLp,"");
     XPRSgetintattrib(mLp, XPRS_LPSTATUS, &xpress_stat);
   }
 

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1912,16 +1912,10 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
 
   int xpress_stat = 0;
   if (mMip) {
-    if (this->maximize_)
-      status = XPRSmaxim(mLp, "g");
-    else
-      status = XPRSminim(mLp, "g");
+    status = XPRSmipoptimize(mLp, "g");
     XPRSgetintattrib(mLp, XPRS_MIPSTATUS, &xpress_stat);
   } else {
-    if (this->maximize_)
-      status = XPRSmaxim(mLp, "");
-    else
-      status = XPRSminim(mLp, "");
+    status = XPRSlpoptimize(mLp, "g");
     XPRSgetintattrib(mLp, XPRS_LPSTATUS, &xpress_stat);
   }
 

--- a/ortools/xpress/environment.cc
+++ b/ortools/xpress/environment.cc
@@ -92,8 +92,6 @@ std::function<int(XPRSprob prob, int nrows, const int rowind[], const char rowty
 std::function<int(XPRSprob prob, void (XPRS_CC *f_intsol)(XPRSprob cbprob, void* cbdata), void* p, int priority)> XPRSaddcbintsol = nullptr;
 std::function<int(XPRSprob prob, void (XPRS_CC *f_intsol)(XPRSprob cbprob, void* cbdata), void* p)> XPRSremovecbintsol = nullptr;
 std::function<int(XPRSprob prob, void (XPRS_CC *f_message)(XPRSprob cbprob, void* cbdata, const char* msg, int msglen, int msgtype), void* p, int priority)> XPRSaddcbmessage = nullptr;
-std::function<int(XPRSprob prob, const char* flags)> XPRSminim = nullptr;
-std::function<int(XPRSprob prob, const char* flags)> XPRSmaxim = nullptr;
 std::function<int(XPRSprob prob, const char* flags)> XPRSlpoptimize = nullptr;
 std::function<int(XPRSprob prob, const char* flags)> XPRSmipoptimize = nullptr;
 
@@ -158,8 +156,6 @@ absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
   xpress_dynamic_library->GetFunction(&XPRSaddcbintsol, "XPRSaddcbintsol");
   xpress_dynamic_library->GetFunction(&XPRSremovecbintsol, "XPRSremovecbintsol");
   xpress_dynamic_library->GetFunction(&XPRSaddcbmessage, "XPRSaddcbmessage");
-  xpress_dynamic_library->GetFunction(&XPRSminim, "XPRSminim");
-  xpress_dynamic_library->GetFunction(&XPRSmaxim, "XPRSmaxim");
   xpress_dynamic_library->GetFunction(&XPRSlpoptimize, "XPRSlpoptimize");
   xpress_dynamic_library->GetFunction(&XPRSmipoptimize, "XPRSmipoptimize");
 

--- a/ortools/xpress/environment.cc
+++ b/ortools/xpress/environment.cc
@@ -94,6 +94,8 @@ std::function<int(XPRSprob prob, void (XPRS_CC *f_intsol)(XPRSprob cbprob, void*
 std::function<int(XPRSprob prob, void (XPRS_CC *f_message)(XPRSprob cbprob, void* cbdata, const char* msg, int msglen, int msgtype), void* p, int priority)> XPRSaddcbmessage = nullptr;
 std::function<int(XPRSprob prob, const char* flags)> XPRSminim = nullptr;
 std::function<int(XPRSprob prob, const char* flags)> XPRSmaxim = nullptr;
+std::function<int(XPRSprob prob, const char* flags)> XPRSlpoptimize = nullptr;
+std::function<int(XPRSprob prob, const char* flags)> XPRSmipoptimize = nullptr;
 
 absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
   // This was generated with the parse_header_xpress.py script.
@@ -158,6 +160,9 @@ absl::Status LoadXpressFunctions(DynamicLibrary* xpress_dynamic_library) {
   xpress_dynamic_library->GetFunction(&XPRSaddcbmessage, "XPRSaddcbmessage");
   xpress_dynamic_library->GetFunction(&XPRSminim, "XPRSminim");
   xpress_dynamic_library->GetFunction(&XPRSmaxim, "XPRSmaxim");
+  xpress_dynamic_library->GetFunction(&XPRSlpoptimize, "XPRSlpoptimize");
+  xpress_dynamic_library->GetFunction(&XPRSmipoptimize, "XPRSmipoptimize");
+
 
   auto notFound = xpress_dynamic_library->FunctionsNotFound();
   if (!notFound.empty()) {

--- a/ortools/xpress/environment.h
+++ b/ortools/xpress/environment.h
@@ -491,8 +491,6 @@ extern std::function<int(XPRSprob prob, int nrows, const int rowind[], const cha
 extern std::function<int(XPRSprob prob, void (XPRS_CC *f_intsol)(XPRSprob cbprob, void* cbdata), void* p, int priority)> XPRSaddcbintsol;
 extern std::function<int(XPRSprob prob, void (XPRS_CC *f_intsol)(XPRSprob cbprob, void* cbdata), void* p)> XPRSremovecbintsol;
 extern std::function<int(XPRSprob prob, void (XPRS_CC *f_message)(XPRSprob cbprob, void* cbdata, const char* msg, int msglen, int msgtype), void* p, int priority)> XPRSaddcbmessage;
-extern std::function<int(XPRSprob prob, const char* flags)> XPRSminim;
-extern std::function<int(XPRSprob prob, const char* flags)> XPRSmaxim;
 extern std::function<int(XPRSprob prob, const char* flags)> XPRSlpoptimize;
 extern std::function<int(XPRSprob prob, const char* flags)> XPRSmipoptimize;
 

--- a/ortools/xpress/environment.h
+++ b/ortools/xpress/environment.h
@@ -493,6 +493,8 @@ extern std::function<int(XPRSprob prob, void (XPRS_CC *f_intsol)(XPRSprob cbprob
 extern std::function<int(XPRSprob prob, void (XPRS_CC *f_message)(XPRSprob cbprob, void* cbdata, const char* msg, int msglen, int msgtype), void* p, int priority)> XPRSaddcbmessage;
 extern std::function<int(XPRSprob prob, const char* flags)> XPRSminim;
 extern std::function<int(XPRSprob prob, const char* flags)> XPRSmaxim;
+extern std::function<int(XPRSprob prob, const char* flags)> XPRSlpoptimize;
+extern std::function<int(XPRSprob prob, const char* flags)> XPRSmipoptimize;
 
 }  // namespace operations_research
 

--- a/ortools/xpress/parse_header_xpress.py
+++ b/ortools/xpress/parse_header_xpress.py
@@ -112,7 +112,7 @@ class XpressHeaderParser(object):
                                      "XPRSwriteprob", "XPRSgetrowtype", "XPRSgetcoltype", "XPRSgetlpsol",
                                      "XPRSgetmipsol", "XPRSchgbounds", "XPRSchgobj", "XPRSchgcoef", "XPRSchgmcoef",
                                      "XPRSchgrhs", "XPRSchgrhsrange", "XPRSchgrowtype", "XPRSaddcbmessage", "XPRSsetcbmessage",
-                                     "XPRSminim", "XPRSmaxim", "XPRSaddmipsol", "XPRSaddcbintsol", "XPRSremovecbintsol",
+                                     "XPRSaddmipsol", "XPRSaddcbintsol", "XPRSremovecbintsol",
                                      "XPRSinterrupt", "XPRSlpoptimize", "XPRSmipoptimize"}
         self.__missing_required_functions = self.__required_functions
         self.__XPRSprob_section = False

--- a/ortools/xpress/parse_header_xpress.py
+++ b/ortools/xpress/parse_header_xpress.py
@@ -113,7 +113,7 @@ class XpressHeaderParser(object):
                                      "XPRSgetmipsol", "XPRSchgbounds", "XPRSchgobj", "XPRSchgcoef", "XPRSchgmcoef",
                                      "XPRSchgrhs", "XPRSchgrhsrange", "XPRSchgrowtype", "XPRSaddcbmessage", "XPRSsetcbmessage",
                                      "XPRSminim", "XPRSmaxim", "XPRSaddmipsol", "XPRSaddcbintsol", "XPRSremovecbintsol",
-                                     "XPRSinterrupt"}
+                                     "XPRSinterrupt", "XPRSlpoptimize", "XPRSmipoptimize"}
         self.__missing_required_functions = self.__required_functions
         self.__XPRSprob_section = False
 


### PR DESCRIPTION
`XPRSminim` and `XPRSmaxim`are deprecated see [xpress doc](https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/HTML/XPRSmaxim.html)
I propose to use `XPRSlpoptimize` and `XPRSmipoptimize` as suggested by the doc