### PR TITLE
MPSolverToXpressBasisStatus should consider 5 enum values

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1267,6 +1267,8 @@ static int MPSolverToXpressBasisStatus(MPSolver::BasisStatus mpsolver_basis_stat
       return XPRS_AT_UPPER;
     case MPSolver::FREE:
       return XPRS_FREE_SUPER;
+    case MPSolver::FIXED_VALUE:
+      return XPRS_BASIC;
     default:
       LOG(DFATAL) << "Unknown MPSolver basis status";
       return XPRS_FREE_SUPER;


### PR DESCRIPTION
We forgot to convert the 5th value of `MPSolver::BasisStatus`
