### PR TITLE
Set generic parameters before specific ones in xpress interface

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1829,14 +1829,14 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
 
   // Set log level.
   XPRSsetintcontrol(mLp, XPRS_OUTPUTLOG, quiet() ? 0 : 1);
-  // Set parameters.
-  // NOTE: We must invoke SetSolverSpecificParametersAsString() _first_.
-  //       Its current implementation invokes ReadParameterFile() which in
-  //       turn invokes XPRSreadcopyparam(). The latter will _overwrite_
-  //       all current parameter settings in the environment.
+  // We first set our internal MPSolverParameters from 'param' and then set
+  // any user-specified internal solver parameters via
+  // solver_specific_parameter_string_.
+  // Default MPSolverParameters can override custom parameters (for example for
+  // presolving) and therefore we apply MPSolverParameters first.
+  SetParameters(param);
   solver_->SetSolverSpecificParametersAsString(
       solver_->solver_specific_parameter_string_);
-  SetParameters(param);
   if (solver_->time_limit()) {
     VLOG(1) << "Setting time limit = " << solver_->time_limit() << " ms.";
     // In Xpress, a time limit should usually have a negative sign. With a

--- a/ortools/linear_solver/xpress_interface_test.cc
+++ b/ortools/linear_solver/xpress_interface_test.cc
@@ -730,22 +730,30 @@ TEST_F(XpressFixtureMIP, Write) {
   tmpFile.close();
   std::filesystem::remove_all(temporary_working_dir);
 
-  std::string expectedMps =
-      std::string("") + "NAME          newProb" + "\n" + "OBJSENSE  MAXIMIZE" +
-      "\n" + "ROWS" + "\n" + " N  __OBJ___        " + "\n" +
-      " L  R1              " + "\n" + " L  SomeRowName     " + "\n" +
-      "COLUMNS" + "\n" + "    C1                __OBJ___          1" + "\n" +
+  std::string expectedMps = std::string("") +
+      "NAME          newProb" + "\n" +
+      "OBJSENSE  MAXIMIZE" + "\n" +
+      "ROWS" + "\n" +
+      " N  __OBJ___        " + "\n" +
+      " L  R1              " + "\n" +
+      " L  SomeRowName     " + "\n" +
+      "COLUMNS" + "\n" +
+      "    C1                __OBJ___          1" + "\n" +
       "    C1                R1                3" + "\n" +
       "    SomeColumnName    __OBJ___          2" + "\n" +
       "    SomeColumnName    R1                1.5" + "\n" +
       "    SomeColumnName    SomeRowName       -1.1122334455667788" + "\n" +
-      "RHS" + "\n" + "    RHS00001          R1                1" + "\n" +
-      "    RHS00001          SomeRowName       5" + "\n" + "RANGES" + "\n" +
-      "    RNG00001          SomeRowName       2" + "\n" + "BOUNDS" + "\n" +
+      "RHS" + "\n" +
+      "    RHS00001          R1                1" + "\n" +
+      "    RHS00001          SomeRowName       5" + "\n" +
+      "RANGES" + "\n" +
+      "    RNG00001          SomeRowName       2" + "\n" +
+      "BOUNDS" + "\n" +
       " UI BND00001          C1                9" + "\n" +
       " LO BND00001          C1                -1" + "\n" +
       " UP BND00001          SomeColumnName    5.147593849384714" + "\n" +
-      " LO BND00001          SomeColumnName    -1" + "\n" + "ENDATA" + "\n";
+      " LO BND00001          SomeColumnName    -1" + "\n" +
+      "ENDATA" + "\n";
 
   EXPECT_EQ(tmpBuffer.str(), expectedMps);
 }
@@ -852,7 +860,6 @@ TEST_F(XpressFixtureMIP, SetScalingNotOverridenByMPSolverParameters) {
   solver.SetSolverSpecificParametersAsString(xpressParamString);
   solver.Solve();
   EXPECT_EQ(getter.getIntegerControl(XPRS_SCALING), scaling);
-}
 }
 
 TEST_F(XpressFixtureMIP, SetRelativeMipGap) {

--- a/ortools/linear_solver/xpress_interface_test.cc
+++ b/ortools/linear_solver/xpress_interface_test.cc
@@ -730,30 +730,22 @@ TEST_F(XpressFixtureMIP, Write) {
   tmpFile.close();
   std::filesystem::remove_all(temporary_working_dir);
 
-  std::string expectedMps = std::string("") +
-      "NAME          newProb" + "\n" +
-      "OBJSENSE  MAXIMIZE" + "\n" +
-      "ROWS" + "\n" +
-      " N  __OBJ___        " + "\n" +
-      " L  R1              " + "\n" +
-      " L  SomeRowName     " + "\n" +
-      "COLUMNS" + "\n" +
-      "    C1                __OBJ___          1" + "\n" +
+  std::string expectedMps =
+      std::string("") + "NAME          newProb" + "\n" + "OBJSENSE  MAXIMIZE" +
+      "\n" + "ROWS" + "\n" + " N  __OBJ___        " + "\n" +
+      " L  R1              " + "\n" + " L  SomeRowName     " + "\n" +
+      "COLUMNS" + "\n" + "    C1                __OBJ___          1" + "\n" +
       "    C1                R1                3" + "\n" +
       "    SomeColumnName    __OBJ___          2" + "\n" +
       "    SomeColumnName    R1                1.5" + "\n" +
       "    SomeColumnName    SomeRowName       -1.1122334455667788" + "\n" +
-      "RHS" + "\n" +
-      "    RHS00001          R1                1" + "\n" +
-      "    RHS00001          SomeRowName       5" + "\n" +
-      "RANGES" + "\n" +
-      "    RNG00001          SomeRowName       2" + "\n" +
-      "BOUNDS" + "\n" +
+      "RHS" + "\n" + "    RHS00001          R1                1" + "\n" +
+      "    RHS00001          SomeRowName       5" + "\n" + "RANGES" + "\n" +
+      "    RNG00001          SomeRowName       2" + "\n" + "BOUNDS" + "\n" +
       " UI BND00001          C1                9" + "\n" +
       " LO BND00001          C1                -1" + "\n" +
       " UP BND00001          SomeColumnName    5.147593849384714" + "\n" +
-      " LO BND00001          SomeColumnName    -1" + "\n" +
-      "ENDATA" + "\n";
+      " LO BND00001          SomeColumnName    -1" + "\n" + "ENDATA" + "\n";
 
   EXPECT_EQ(tmpBuffer.str(), expectedMps);
 }
@@ -766,11 +758,27 @@ TEST_F(XpressFixtureLP, SetPrimalTolerance) {
   EXPECT_EQ(getter.getDoubleControl(XPRS_FEASTOL), tol);
 }
 
+TEST_F(XpressFixtureLP, SetPrimalToleranceNotOverridenByMPSolverParameters) {
+  double tol = 1e-4;  // Choose a value different from kDefaultPrimalTolerance
+  std::string xpressParamString = "FEASTOL " + std::to_string(tol);
+  solver.SetSolverSpecificParametersAsString(xpressParamString);
+  solver.Solve();
+  EXPECT_EQ(getter.getDoubleControl(XPRS_FEASTOL), tol);
+}
+
 TEST_F(XpressFixtureLP, SetDualTolerance) {
   MPSolverParameters params;
   double tol = 1e-2;
   params.SetDoubleParam(MPSolverParameters::DUAL_TOLERANCE, tol);
   solver.Solve(params);
+  EXPECT_EQ(getter.getDoubleControl(XPRS_OPTIMALITYTOL), tol);
+}
+
+TEST_F(XpressFixtureLP, SetDualToleranceNotOverridenByMPSolverParameters) {
+  double tol = 1e-4;  // Choose a value different from kDefaultDualTolerance
+  std::string xpressParamString = "OPTIMALITYTOL " + std::to_string(tol);
+  solver.SetSolverSpecificParametersAsString(xpressParamString);
+  solver.Solve();
   EXPECT_EQ(getter.getDoubleControl(XPRS_OPTIMALITYTOL), tol);
 }
 
@@ -784,6 +792,17 @@ TEST_F(XpressFixtureMIP, SetPresolveMode) {
                          MPSolverParameters::PRESOLVE_ON);
   solver.Solve(params);
   EXPECT_EQ(getter.getIntegerControl(XPRS_PRESOLVE), 1);
+}
+
+TEST_F(XpressFixtureMIP, SetPresolveModeNotOverridenByMPSolverParameters) {
+  // Test all presolve modes of Xpress
+  std::vector<int> presolveModes{-1, 0, 1, 2, 3};
+  for (int presolveMode : presolveModes) {
+    std::string xpressParamString = "PRESOLVE " + std::to_string(presolveMode);
+    solver.SetSolverSpecificParametersAsString(xpressParamString);
+    solver.Solve();
+    EXPECT_EQ(getter.getIntegerControl(XPRS_PRESOLVE), presolveMode);
+  }
 }
 
 TEST_F(XpressFixtureLP, SetLpAlgorithm) {
@@ -802,6 +821,16 @@ TEST_F(XpressFixtureLP, SetLpAlgorithm) {
   EXPECT_EQ(getter.getIntegerControl(XPRS_DEFAULTALG), 4);
 }
 
+TEST_F(XpressFixtureLP, SetLPAlgorithmNotOverridenByMPSolverParameters) {
+  std::vector<int> defaultAlgs{1, 2, 3, 4};
+  for (int defaultAlg : defaultAlgs) {
+    std::string xpressParamString = "DEFAULTALG " + std::to_string(defaultAlg);
+    solver.SetSolverSpecificParametersAsString(xpressParamString);
+    solver.Solve();
+    EXPECT_EQ(getter.getIntegerControl(XPRS_DEFAULTALG), defaultAlg);
+  }
+}
+
 TEST_F(XpressFixtureMIP, SetScaling) {
   MPSolverParameters params;
   params.SetIntegerParam(MPSolverParameters::SCALING,
@@ -814,12 +843,32 @@ TEST_F(XpressFixtureMIP, SetScaling) {
   EXPECT_EQ(getter.getIntegerControl(XPRS_SCALING), 163);
 }
 
+TEST_F(XpressFixtureMIP, SetScalingNotOverridenByMPSolverParameters) {
+  // Scaling is a bitmap on 16 bits in Xpress, test only a random value among
+  // all possible
+  int scaling = 2354;
+
+  std::string xpressParamString = "SCALING " + std::to_string(scaling);
+  solver.SetSolverSpecificParametersAsString(xpressParamString);
+  solver.Solve();
+  EXPECT_EQ(getter.getIntegerControl(XPRS_SCALING), scaling);
+}
+}
+
 TEST_F(XpressFixtureMIP, SetRelativeMipGap) {
   MPSolverParameters params;
   double relativeMipGap = 1e-3;
   params.SetDoubleParam(MPSolverParameters::RELATIVE_MIP_GAP, relativeMipGap);
   solver.Solve(params);
   EXPECT_EQ(getter.getDoubleControl(XPRS_MIPRELSTOP), relativeMipGap);
+}
+
+TEST_F(XpressFixtureMIP, SetRelativeMipGapNotOverridenByMPSolverParameters) {
+  double gap = 1e-2;  // Choose a value different from kDefaultRelativeMipGap
+  std::string xpressParamString = "MIPRELSTOP " + std::to_string(gap);
+  solver.SetSolverSpecificParametersAsString(xpressParamString);
+  solver.Solve();
+  EXPECT_EQ(getter.getDoubleControl(XPRS_MIPRELSTOP), gap);
 }
 
 TEST(XpressInterface, setStringControls) {


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->

Set specific parameters before generic parameters in Xpress interface, closes #127 