### PR TITLE
Set Xpress specific parameters before generic ones

### DIFF
--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1822,13 +1822,14 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
   // Set log level.
   XPRSsetintcontrol(mLp, XPRS_OUTPUTLOG, quiet() ? 0 : 1);
   // Set parameters.
-  // NOTE: We must invoke SetSolverSpecificParametersAsString() _first_.
-  //       Its current implementation invokes ReadParameterFile() which in
-  //       turn invokes XPRSreadcopyparam(). The latter will _overwrite_
-  //       all current parameter settings in the environment.
+  // We first set our internal MPSolverParameters from 'param' and then set
+  // any user-specified internal solver parameters via
+  // solver_specific_parameter_string_.
+  // Default MPSolverParameters can override custom parameters (for example for
+  // presolving) and therefore we apply MPSolverParameters first.
+  SetParameters(param);
   solver_->SetSolverSpecificParametersAsString(
       solver_->solver_specific_parameter_string_);
-  SetParameters(param);
   if (solver_->time_limit()) {
     VLOG(1) << "Setting time limit = " << solver_->time_limit() << " ms.";
     // In Xpress, a time limit should usually have a negative sign. With a

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -277,13 +277,12 @@ class MPCallbackWrapper {
     for (const std::exception_ptr& ex : caught_exceptions_) {
       try {
         std::rethrow_exception(ex);
-      } catch (std::exception& ex) {
+      } catch (std::exception &ex) {
         // We don't want the interface to throw exceptions, plus it causes
         // SWIG issues in Java & Python. Instead, we'll only log them.
         // (The use cases where the user has to raise an exception inside their
         // call-back does not seem to be frequent, anyway.)
-        LOG(ERROR) << "Caught exception during user-defined call-back: "
-                   << ex.what();
+        LOG(ERROR) << "Caught exception during user-defined call-back: " << ex.what();
       }
     }
     caught_exceptions_.clear();
@@ -1721,14 +1720,13 @@ std::vector<int> XpressBasisStatusesFrom(
 
 void XpressInterface::SetStartingLpBasis(
     const std::vector<MPSolver::BasisStatus>& variable_statuses,
-    const std::vector<MPSolver::BasisStatus>& constraint_statuses) {
+    const std::vector<MPSolver::BasisStatus>& constraint_statuses){
   if (mMip) {
     LOG(DFATAL) << __FUNCTION__ << " is only available for LP problems";
     return;
   }
   initial_variables_basis_status_ = XpressBasisStatusesFrom(variable_statuses);
-  initial_constraint_basis_status_ =
-      XpressBasisStatusesFrom(constraint_statuses);
+  initial_constraint_basis_status_ = XpressBasisStatusesFrom(constraint_statuses);
 }
 
 bool XpressInterface::readParameters(std::istream& is, char sep) {
@@ -1841,8 +1839,7 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
 
   // Load basis if present
   // TODO : check number of variables / constraints
-  if (!mMip && !initial_variables_basis_status_.empty() &&
-      !initial_constraint_basis_status_.empty()) {
+  if (!mMip && !initial_variables_basis_status_.empty() && !initial_constraint_basis_status_.empty()) {
     CHECK_STATUS(XPRSloadbasis(mLp, initial_constraint_basis_status_.data(),
                                initial_variables_basis_status_.data()));
   }
@@ -1866,10 +1863,10 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
 
   int xpress_stat = 0;
   if (mMip) {
-    status = XPRSmipoptimize(mLp, "");
+    status = XPRSmipoptimize(mLp,"");
     XPRSgetintattrib(mLp, XPRS_MIPSTATUS, &xpress_stat);
   } else {
-    status = XPRSlpoptimize(mLp, "");
+    status = XPRSlpoptimize(mLp,"");
     XPRSgetintattrib(mLp, XPRS_LPSTATUS, &xpress_stat);
   }
 

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -1825,7 +1825,8 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
   // We first set our internal MPSolverParameters from 'param' and then set
   // any user-specified internal solver parameters via
   // solver_specific_parameter_string_.
-  // Default MPSolverParameters can override custom parameters (for example for
+  // Default MPSolverParameters can override custom parameters while specific
+  // parameters allow a higher level of customization (for example for
   // presolving) and therefore we apply MPSolverParameters first.
   SetParameters(param);
   solver_->SetSolverSpecificParametersAsString(

--- a/ortools/linear_solver/xpress_interface.cc
+++ b/ortools/linear_solver/xpress_interface.cc
@@ -277,12 +277,13 @@ class MPCallbackWrapper {
     for (const std::exception_ptr& ex : caught_exceptions_) {
       try {
         std::rethrow_exception(ex);
-      } catch (std::exception &ex) {
+      } catch (std::exception& ex) {
         // We don't want the interface to throw exceptions, plus it causes
         // SWIG issues in Java & Python. Instead, we'll only log them.
         // (The use cases where the user has to raise an exception inside their
         // call-back does not seem to be frequent, anyway.)
-        LOG(ERROR) << "Caught exception during user-defined call-back: " << ex.what();
+        LOG(ERROR) << "Caught exception during user-defined call-back: "
+                   << ex.what();
       }
     }
     caught_exceptions_.clear();
@@ -1720,13 +1721,14 @@ std::vector<int> XpressBasisStatusesFrom(
 
 void XpressInterface::SetStartingLpBasis(
     const std::vector<MPSolver::BasisStatus>& variable_statuses,
-    const std::vector<MPSolver::BasisStatus>& constraint_statuses){
+    const std::vector<MPSolver::BasisStatus>& constraint_statuses) {
   if (mMip) {
     LOG(DFATAL) << __FUNCTION__ << " is only available for LP problems";
     return;
   }
   initial_variables_basis_status_ = XpressBasisStatusesFrom(variable_statuses);
-  initial_constraint_basis_status_ = XpressBasisStatusesFrom(constraint_statuses);
+  initial_constraint_basis_status_ =
+      XpressBasisStatusesFrom(constraint_statuses);
 }
 
 bool XpressInterface::readParameters(std::istream& is, char sep) {
@@ -1841,7 +1843,8 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
 
   // Load basis if present
   // TODO : check number of variables / constraints
-  if (!mMip && !initial_variables_basis_status_.empty() && !initial_constraint_basis_status_.empty()) {
+  if (!mMip && !initial_variables_basis_status_.empty() &&
+      !initial_constraint_basis_status_.empty()) {
     CHECK_STATUS(XPRSloadbasis(mLp, initial_constraint_basis_status_.data(),
                                initial_variables_basis_status_.data()));
   }
@@ -1865,10 +1868,10 @@ MPSolver::ResultStatus XpressInterface::Solve(MPSolverParameters const& param) {
 
   int xpress_stat = 0;
   if (mMip) {
-    status = XPRSmipoptimize(mLp,"");
+    status = XPRSmipoptimize(mLp, "");
     XPRSgetintattrib(mLp, XPRS_MIPSTATUS, &xpress_stat);
   } else {
-    status = XPRSlpoptimize(mLp,"");
+    status = XPRSlpoptimize(mLp, "");
     XPRSgetintattrib(mLp, XPRS_LPSTATUS, &xpress_stat);
   }
 

--- a/ortools/linear_solver/xpress_interface_test.cc
+++ b/ortools/linear_solver/xpress_interface_test.cc
@@ -285,9 +285,9 @@ class MyMPCallback : public MPCallback {
   MyMPCallback(MPSolver* mpSolver, bool should_throw)
       : MPCallback(false, false),
         mpSolver_(mpSolver),
-        should_throw_(should_throw){};
+        should_throw_(should_throw) {};
 
-  ~MyMPCallback() override{};
+  ~MyMPCallback() override {};
 
   void RunCallback(MPCallbackContext* callback_context) override {
     if (should_throw_) {

--- a/ortools/linear_solver/xpress_interface_test.cc
+++ b/ortools/linear_solver/xpress_interface_test.cc
@@ -285,9 +285,9 @@ class MyMPCallback : public MPCallback {
   MyMPCallback(MPSolver* mpSolver, bool should_throw)
       : MPCallback(false, false),
         mpSolver_(mpSolver),
-        should_throw_(should_throw) {};
+        should_throw_(should_throw){};
 
-  ~MyMPCallback() override {};
+  ~MyMPCallback() override{};
 
   void RunCallback(MPCallbackContext* callback_context) override {
     if (should_throw_) {

--- a/ortools/linear_solver/xpress_interface_test.cc
+++ b/ortools/linear_solver/xpress_interface_test.cc
@@ -768,11 +768,27 @@ TEST_F(XpressFixtureLP, SetPrimalTolerance) {
   EXPECT_EQ(getter.getDoubleControl(XPRS_FEASTOL), tol);
 }
 
+TEST_F(XpressFixtureLP, SetPrimalToleranceNotOverridenByMPSolverParameters) {
+  double tol = 1e-4;  // Choose a value different from kDefaultPrimalTolerance
+  std::string xpressParamString = "FEASTOL " + std::to_string(tol);
+  solver.SetSolverSpecificParametersAsString(xpressParamString);
+  solver.Solve();
+  EXPECT_EQ(getter.getDoubleControl(XPRS_FEASTOL), tol);
+}
+
 TEST_F(XpressFixtureLP, SetDualTolerance) {
   MPSolverParameters params;
   double tol = 1e-2;
   params.SetDoubleParam(MPSolverParameters::DUAL_TOLERANCE, tol);
   solver.Solve(params);
+  EXPECT_EQ(getter.getDoubleControl(XPRS_OPTIMALITYTOL), tol);
+}
+
+TEST_F(XpressFixtureLP, SetDualToleranceNotOverridenByMPSolverParameters) {
+  double tol = 1e-4;  // Choose a value different from kDefaultDualTolerance
+  std::string xpressParamString = "OPTIMALITYTOL " + std::to_string(tol);
+  solver.SetSolverSpecificParametersAsString(xpressParamString);
+  solver.Solve();
   EXPECT_EQ(getter.getDoubleControl(XPRS_OPTIMALITYTOL), tol);
 }
 
@@ -786,6 +802,17 @@ TEST_F(XpressFixtureMIP, SetPresolveMode) {
                          MPSolverParameters::PRESOLVE_ON);
   solver.Solve(params);
   EXPECT_EQ(getter.getIntegerControl(XPRS_PRESOLVE), 1);
+}
+
+TEST_F(XpressFixtureMIP, SetPresolveModeNotOverridenByMPSolverParameters) {
+  // Test all presolve modes of Xpress
+  std::vector<int> presolveModes{-1, 0, 1, 2, 3};
+  for (int presolveMode : presolveModes) {
+    std::string xpressParamString = "PRESOLVE " + std::to_string(presolveMode);
+    solver.SetSolverSpecificParametersAsString(xpressParamString);
+    solver.Solve();
+    EXPECT_EQ(getter.getIntegerControl(XPRS_PRESOLVE), presolveMode);
+  }
 }
 
 TEST_F(XpressFixtureLP, SetLpAlgorithm) {
@@ -804,6 +831,16 @@ TEST_F(XpressFixtureLP, SetLpAlgorithm) {
   EXPECT_EQ(getter.getIntegerControl(XPRS_DEFAULTALG), 4);
 }
 
+TEST_F(XpressFixtureLP, SetLPAlgorithmNotOverridenByMPSolverParameters) {
+  std::vector<int> defaultAlgs{1, 2, 3, 4};
+  for (int defaultAlg : defaultAlgs) {
+    std::string xpressParamString = "DEFAULTALG " + std::to_string(defaultAlg);
+    solver.SetSolverSpecificParametersAsString(xpressParamString);
+    solver.Solve();
+    EXPECT_EQ(getter.getIntegerControl(XPRS_DEFAULTALG), defaultAlg);
+  }
+}
+
 TEST_F(XpressFixtureMIP, SetScaling) {
   MPSolverParameters params;
   params.SetIntegerParam(MPSolverParameters::SCALING,
@@ -816,12 +853,31 @@ TEST_F(XpressFixtureMIP, SetScaling) {
   EXPECT_EQ(getter.getIntegerControl(XPRS_SCALING), 163);
 }
 
+TEST_F(XpressFixtureMIP, SetScalingNotOverridenByMPSolverParameters) {
+  // Scaling is a bitmap on 16 bits in Xpress, test only a random value among
+  // all possible
+  int scaling = 2354;
+
+  std::string xpressParamString = "SCALING " + std::to_string(scaling);
+  solver.SetSolverSpecificParametersAsString(xpressParamString);
+  solver.Solve();
+  EXPECT_EQ(getter.getIntegerControl(XPRS_SCALING), scaling);
+}
+
 TEST_F(XpressFixtureMIP, SetRelativeMipGap) {
   MPSolverParameters params;
   double relativeMipGap = 1e-3;
   params.SetDoubleParam(MPSolverParameters::RELATIVE_MIP_GAP, relativeMipGap);
   solver.Solve(params);
   EXPECT_EQ(getter.getDoubleControl(XPRS_MIPRELSTOP), relativeMipGap);
+}
+
+TEST_F(XpressFixtureMIP, SetRelativeMipGapNotOverridenByMPSolverParameters) {
+  double gap = 1e-2;  // Choose a value different from kDefaultRelativeMipGap
+  std::string xpressParamString = "MIPRELSTOP " + std::to_string(gap);
+  solver.SetSolverSpecificParametersAsString(xpressParamString);
+  solver.Solve();
+  EXPECT_EQ(getter.getDoubleControl(XPRS_MIPRELSTOP), gap);
 }
 
 TEST(XpressInterface, setStringControls) {


### PR DESCRIPTION
<!--
Thank you for submitting a PR!

Please make sure you are targeting the main branch instead of stable and that all contributors have signed the Contributor License Agreement.

This simply gives us permission to use and redistribute your contributions as part of the project.
Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.

This project follows https://opensource.google.com/conduct/

Thanks!
-->
Set specific parameters before generic parameters in Xpress interface, closes https://github.com/rte-france/or-tools/issues/127